### PR TITLE
Improve messaging functions

### DIFF
--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -7,6 +7,7 @@
 
 // local includes
 #include "args.h"
+#include "conda.h"
 #include "system_requirements.h"
 #include "tpl.h"
 

--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -652,6 +652,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'v':
                 globals.verbose = true;
+                LOG_LEVEL++;
                 break;
             case OPT_OVERWRITE:
                 globals.enable_overwrite = true;

--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -722,6 +722,8 @@ int main(int argc, char *argv[]) {
     printf(BANNER, version, AUTHOR);
     guard_free(version);
 
+    SYSDEBUG("LOG_LEVEL is %s", log_get_level_str());
+
     setup_python_version_override(&ctx, python_override_version);
     configure_stasis_ini(&ctx, &config_input);
     check_system_path();

--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -36,13 +36,13 @@ static void setup_python_version_override(struct Delivery *ctx, const char *vers
         guard_free(ctx->meta.python);
         ctx->meta.python = strdup(version);
         if (!ctx->meta.python) {
-            SYSERROR("%s", "Unable to allocate bytes for python version override");
+            SYSERROR("Unable to allocate bytes for python version override");
             exit(1);
         }
         guard_free(ctx->meta.python_compact);
         ctx->meta.python_compact = to_short_version(ctx->meta.python);
         if (!ctx->meta.python_compact) {
-            SYSERROR("%s", "Unable to allocate bytes for python compact version override");
+            SYSERROR("Unable to allocate bytes for python compact version override");
             exit(1);
         }
     }
@@ -50,7 +50,7 @@ static void setup_python_version_override(struct Delivery *ctx, const char *vers
 
 static void configure_stasis_ini(struct Delivery *ctx, char **config_input) {
     if (!*config_input) {
-        SYSDEBUG("%s", "No configuration passed by argument. Using basic config.");
+        SYSDEBUG("No configuration passed by argument. Using basic config.");
         char cfgfile[PATH_MAX * 2];
         snprintf(cfgfile, sizeof(cfgfile), "%s/%s", globals.sysconfdir, "stasis.ini");
         SYSDEBUG("cfgfile: %s", cfgfile);
@@ -61,16 +61,16 @@ static void configure_stasis_ini(struct Delivery *ctx, char **config_input) {
         }
     }
 
-    SYSDEBUG("Reading STASIS global configuration: %s\n", *config_input);
+    SYSDEBUG("Reading STASIS global configuration: %s", *config_input);
     ctx->_stasis_ini_fp.cfg = ini_open(*config_input);
     if (!ctx->_stasis_ini_fp.cfg) {
         msg(STASIS_MSG_ERROR, "Failed to read global config file: %s, %s\n", *config_input, strerror(errno));
-        SYSERROR("Failed to read global config file: %s\n", *config_input);
+        SYSERROR("Failed to read global config file: %s", *config_input);
         exit(1);
     }
     ctx->_stasis_ini_fp.cfg_path = strdup(*config_input);
     if (!ctx->_stasis_ini_fp.cfg_path) {
-        SYSERROR("%s", "Failed to allocate memory delivery context global config file name");
+        SYSERROR("Failed to allocate memory delivery context global config file name");
         exit(1);
     }
     guard_free(*config_input);
@@ -210,7 +210,7 @@ static void configure_conda_base(struct Delivery *ctx, char *envs[]) {
         char *mission_base_orig = NULL;
 
         if (asprintf(&mission_base_orig, "%s/%s/base.yml", ctx->storage.mission_dir, ctx->meta.mission) < 0) {
-            SYSERROR("Unable to allocate bytes for %s/%s/base.yml path\n", ctx->storage.mission_dir, ctx->meta.mission);
+            SYSERROR("Unable to allocate bytes for %s/%s/base.yml path", ctx->storage.mission_dir, ctx->meta.mission);
             exit(1);
         }
 
@@ -221,7 +221,7 @@ static void configure_conda_base(struct Delivery *ctx, char *envs[]) {
         } else {
             msg(STASIS_MSG_L2, "Using base environment configuration: %s\n", mission_base_orig);
             if (asprintf(&mission_base, "%s/%s-base.yml", ctx->storage.tmpdir, ctx->info.release_name) < 0) {
-                SYSERROR("%s", "Unable to allocate bytes for temporary base.yml configuration");
+                SYSERROR("Unable to allocate bytes for temporary base.yml configuration");
                 remove(mission_base);
                 exit(1);
             }
@@ -528,7 +528,7 @@ static void transfer_artifacts(struct Delivery *ctx) {
 
 static char *center_text(const char *s, const size_t maxwidth) {
     if (maxwidth < 2) {
-        SYSERROR("%s", "maximum width must be greater than 0");
+        SYSERROR("maximum width must be greater than 0");
         return NULL;
     }
 
@@ -545,7 +545,7 @@ static char *center_text(const char *s, const size_t maxwidth) {
 
     char *result = calloc(maxwidth + 1, sizeof(*result));
     if (!result) {
-        SYSERROR("%s", "unable to allocate bytes for centered text string");
+        SYSERROR("unable to allocate bytes for centered text string");
         return NULL;
     }
     const size_t middle = (maxwidth / 2) - s_len / 2;
@@ -712,10 +712,10 @@ int main(int argc, char *argv[]) {
 
     char *version = center_text(VERSION, strlen(STASIS_BANNER_HEADER));
     if (!version) {
-        SYSERROR("%s", "version too long?");
+        SYSERROR("version too long?");
         version = strdup(VERSION);
         if (!version) {
-            SYSERROR("%s", "unable to allocate uncentered fallback version string");
+            SYSERROR("unable to allocate uncentered fallback version string");
             exit(1);
         }
     }

--- a/src/cli/stasis_indexer/args.c
+++ b/src/cli/stasis_indexer/args.c
@@ -23,7 +23,7 @@ void usage(char *name) {
     const int maxopts = sizeof(long_options) / sizeof(long_options[0]);
     char *opts = calloc(maxopts + 1, sizeof(char));
     if (!opts) {
-        SYSERROR("%s", "Unable to allocate memory for options array");
+        SYSERROR("Unable to allocate memory for options array");
         exit(1);
     }
     for (int i = 0; i < maxopts; i++) {

--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -167,7 +167,7 @@ int micromamba_configure(const struct Delivery *ctx, struct MicromambaInfo *m) {
     // 1 = nul terminator
     char *pathvar = calloc(pathvar_len, sizeof(*pathvar));
     if (!pathvar) {
-        SYSERROR("%s", "Unable to allocate bytes for temporary path string");
+        SYSERROR("Unable to allocate bytes for temporary path string");
         exit(1);
     }
     snprintf(pathvar, pathvar_len, "%s/bin:%s:%s", m->conda_prefix, m->micromamba_prefix, getenv("PATH"));
@@ -252,12 +252,12 @@ int get_files(struct StrList **out, const char *path, const char *pattern, ...) 
     char userpattern[PATH_MAX] = {0};
     const int len = vsnprintf(userpattern, sizeof(userpattern), pattern, args);
     if (len < 0) {
-        SYSERROR("%s", "vsnprintf failed\n");
+        SYSERROR("vsnprintf failed");
         va_end(args);
         return -1;
     }
     if ((size_t) len > sizeof(userpattern)) {
-        fprintf(stderr, "WARNING: %s: userpattern truncated!\n", __FUNCTION__);
+        SYSWARN("%s: userpattern truncated!", __FUNCTION__);
     }
     va_end(args);
     if (!strlen(userpattern)) {
@@ -299,7 +299,7 @@ struct StrList *get_docker_images(struct Delivery *ctx, char *pattern) {
     char *tarball = NULL;
     asprintf(&tarball, "%s*.tar*", pattern);
     if (!tarball) {
-        SYSERROR("%s", "Unable to allocate bytes for docker image wildcard pattern");
+        SYSERROR("Unable to allocate bytes for docker image wildcard pattern");
         return NULL;
     }
     tolower_s(tarball);

--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -2,6 +2,8 @@
 // Created by jhunk on 11/15/24.
 //
 
+#include <fnmatch.h>
+
 #include "core.h"
 #include "helpers.h"
 

--- a/src/cli/stasis_indexer/include/helpers.h
+++ b/src/cli/stasis_indexer/include/helpers.h
@@ -2,6 +2,7 @@
 #define HELPERS_H
 
 #include "delivery.h"
+#include "conda.h"
 
 #define ARRAY_COUNT_DYNAMIC(X, COUNTER) \
     do { \

--- a/src/cli/stasis_indexer/junitxml_report.c
+++ b/src/cli/stasis_indexer/junitxml_report.c
@@ -2,6 +2,8 @@
 // Created by jhunk on 11/15/24.
 //
 
+#include <fnmatch.h>
+
 #include "core.h"
 #include "callbacks.h"
 #include "junitxml.h"

--- a/src/cli/stasis_indexer/junitxml_report.c
+++ b/src/cli/stasis_indexer/junitxml_report.c
@@ -39,7 +39,7 @@ static int write_report_output(struct Delivery *ctx, FILE *destfp, const char *x
         char result_outfile[PATH_MAX] = {0};
         char *short_name_pattern = NULL;
         if (asprintf(&short_name_pattern, "-%s", ctx->info.release_name) < 0 || !short_name_pattern) {
-            SYSERROR("%s", "unable to allocate bytes for short name pattern");
+            SYSERROR("unable to allocate bytes for short name pattern");
             guard_free(bname);
             return -1;
         }

--- a/src/cli/stasis_indexer/readmes.c
+++ b/src/cli/stasis_indexer/readmes.c
@@ -66,7 +66,7 @@ int indexer_readmes(struct Delivery **ctx, const size_t nelem) {
                     if (asprintf(&pattern, "*%s*%s*",
                              latest_deliveries[i]->info.build_number,
                              strstr((*ctx)->rules.release_fmt, "%p") ? latest_deliveries[i]->meta.python_compact : "" ) < 0) {
-                        SYSERROR("%s", "Unable to allocate bytes for pattern");
+                        SYSERROR("Unable to allocate bytes for pattern");
                         fclose(indexfp);
                         return -1;
                     }
@@ -105,7 +105,7 @@ int indexer_readmes(struct Delivery **ctx, const size_t nelem) {
                  current->info.build_number,
                  strstr((*ctx)->rules.release_fmt, "%p") ? current->meta.python_compact : "" );
         if (!pattern) {
-            SYSERROR("%s", "Unable to allocate bytes for pattern");
+            SYSERROR("Unable to allocate bytes for pattern");
             fclose(indexfp);
             return -1;
         }

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -143,7 +143,7 @@ void indexer_init_dirs(struct Delivery *ctx, const char *workdir) {
 
     char *user_dir = expandpath("~/.stasis/indexer");
     if (!user_dir) {
-        SYSERROR("%s", "expandpath failed");
+        SYSERROR("expandpath failed");
     }
 
     path_store(&ctx->storage.output_dir, PATH_MAX, ctx->storage.root, "");
@@ -164,7 +164,7 @@ void indexer_init_dirs(struct Delivery *ctx, const char *workdir) {
         snprintf(newpath, sizeof(newpath), "%s/bin:%s", ctx->storage.tools_dir, getenv("PATH"));
         setenv("PATH", newpath, 1);
     } else {
-        SYSERROR("%s", "environment variable PATH is undefined. Unable to continue.");
+        SYSERROR("environment variable PATH is undefined. Unable to continue.");
         exit(1);
     }
 }
@@ -213,7 +213,7 @@ int main(const int argc, char *argv[]) {
         rootdirs_total = argc - current_index;
         rootdirs = calloc(rootdirs_total + 1, sizeof(*rootdirs));
         if (!rootdirs) {
-            SYSERROR("%s", "unable to allocate memory for rootdirs array");
+            SYSERROR("unable to allocate memory for rootdirs array");
             exit(1);
         }
 
@@ -228,7 +228,7 @@ int main(const int argc, char *argv[]) {
             // use first positional argument
             rootdirs[i] = realpath(argv[optind], NULL);
             if (!rootdirs[i]) {
-                SYSERROR("%s", "Unable to allocate memory for root directory");
+                SYSERROR("Unable to allocate memory for root directory");
                 exit(1);
             }
             optind++;
@@ -311,7 +311,7 @@ int main(const int argc, char *argv[]) {
         rootdirs_total > 1 ? "Merging" : "Indexing",
         rootdirs_total > 1 ? "directories" : "directory");
     if (indexer_combine_rootdirs(workdir, rootdirs, rootdirs_total)) {
-        SYSERROR("%s", "Copy operation failed");
+        SYSERROR("Copy operation failed");
         rmtree(workdir);
         exit(1);
     }
@@ -326,19 +326,19 @@ int main(const int argc, char *argv[]) {
 
     struct MicromambaInfo m;
     if (micromamba_configure(&ctx, &m)) {
-        SYSERROR("%s", "Unable to configure micromamba");
+        SYSERROR("Unable to configure micromamba");
         exit(1);
     }
 
     msg(STASIS_MSG_L1, "Indexing conda packages\n");
     if (indexer_conda(&ctx, m)) {
-        SYSERROR("%s", "Conda package indexing operation failed");
+        SYSERROR("Conda package indexing operation failed");
         exit(1);
     }
 
     msg(STASIS_MSG_L1, "Indexing wheel packages\n");
     if (indexer_wheels(&ctx)) {
-        SYSERROR("%s", "Python package indexing operation failed");
+        SYSERROR("Python package indexing operation failed");
         exit(1);
     }
 
@@ -354,7 +354,7 @@ int main(const int argc, char *argv[]) {
 
     struct Delivery **local = calloc(strlist_count(metafiles) + 1, sizeof(*local));
     if (!local) {
-        SYSERROR("%s", "Unable to allocate bytes for local delivery context array");
+        SYSERROR("Unable to allocate bytes for local delivery context array");
         exit(1);
     }
 
@@ -375,26 +375,26 @@ int main(const int argc, char *argv[]) {
 
     msg(STASIS_MSG_L1, "Generating links to latest release iteration\n");
     if (indexer_symlinks(local, strlist_count(metafiles))) {
-        SYSERROR("%s", "Link generation failed");
+        SYSERROR("Link generation failed");
         exit(1);
     }
 
     msg(STASIS_MSG_L1, "Generating README.md\n");
     if (indexer_readmes(local, strlist_count(metafiles))) {
-        SYSERROR("%s", "README indexing operation failed");
+        SYSERROR("README indexing operation failed");
         exit(1);
     }
 
     msg(STASIS_MSG_L1, "Indexing test results\n");
     if (indexer_junitxml_report(local, strlist_count(metafiles))) {
-        SYSERROR("%s", "Test result indexing operation failed");
+        SYSERROR("Test result indexing operation failed");
         exit(1);
     }
 
     if (do_html) {
         msg(STASIS_MSG_L1, "Generating HTML indexes\n");
         if (indexer_make_website(local)) {
-            SYSERROR("%s", "Site creation failed");
+            SYSERROR("Site creation failed");
             exit(1);
         }
     }
@@ -449,7 +449,7 @@ int main(const int argc, char *argv[]) {
     }
 
     if (system(cmd)) {
-        SYSERROR("%s", "Copy operation failed");
+        SYSERROR("Copy operation failed");
         rmtree(workdir);
         exit(1);
     }

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -198,6 +198,7 @@ int main(const int argc, char *argv[]) {
                 break;
             case 'v':
                 globals.verbose = 1;
+                LOG_LEVEL++;
                 break;
             case 'w':
                 do_html = 1;

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(stasis_core STATIC
         globals.c
+        log.c
         timespec.c
         str.c
         strlist.c

--- a/src/lib/core/artifactory.c
+++ b/src/lib/core/artifactory.c
@@ -8,7 +8,7 @@ int artifactory_download_cli(char *dest,
                              char *os,
                              char *arch,
                              char *remote_filename) {
-    SYSDEBUG("%s", "ARGS follow");
+    SYSDEBUG("ARGS follow");
     SYSDEBUG("dest=%s", dest);
     SYSDEBUG("jfrog_artifactory_base_url=%s", jfrog_artifactory_base_url);
     SYSDEBUG("jfrog_artifactory_product=%s", jfrog_artifactory_product);
@@ -24,7 +24,7 @@ int artifactory_download_cli(char *dest,
     char arch_ident[STASIS_NAME_MAX] = {0};
 
     // convert platform string to lower-case
-    SYSDEBUG("%s", "Set os_ident");
+    SYSDEBUG("Set os_ident");
     strncpy(os_ident, os, sizeof(os_ident) - 1);
     os_ident[sizeof(os_ident) - 1] = '\0';
     tolower_s(os_ident);
@@ -43,7 +43,7 @@ int artifactory_download_cli(char *dest,
     }
 
     // translate ARCH identifier
-    SYSDEBUG("%s", "Set arch_ident");
+    SYSDEBUG("Set arch_ident");
     strncpy(arch_ident, arch, sizeof(arch_ident) - 1);
     arch_ident[sizeof(arch_ident) - 1] = '\0';
     SYSDEBUG("arch_ident=%s", arch_ident);
@@ -65,7 +65,7 @@ int artifactory_download_cli(char *dest,
     arch_ident[sizeof(arch_ident) - 1] = '\0';
 
 
-    SYSDEBUG("%s", "Construct URL");
+    SYSDEBUG("Construct URL");
     snprintf(url, sizeof(url), "%s/%s/%s/%s/%s-%s-%s/%s",
              jfrog_artifactory_base_url,           // https://releases.jfrog.io/artifactory
              jfrog_artifactory_product,            // jfrog-cli
@@ -83,7 +83,7 @@ int artifactory_download_cli(char *dest,
         return -1;
     }
 
-    SYSDEBUG("%s", "Construct path to write data");
+    SYSDEBUG("Construct path to write data");
     SYSDEBUG("path buffer contents: '%s'", path);
     SYSDEBUG("path buffer size: %zu", sizeof(path));
     SYSDEBUG("path strlen: %zu", strlen(path));
@@ -91,10 +91,10 @@ int artifactory_download_cli(char *dest,
 
     snprintf(path + strlen(path), sizeof(path) - strlen(path), "/%s", remote_filename);
     char *errmsg = NULL;
-    SYSDEBUG("%s", "Downloading...");
+    SYSDEBUG("Downloading...");
     long fetch_status = download(url, path, &errmsg);
     if (HTTP_ERROR(fetch_status)) {
-        SYSERROR("download failed: %s: %s\n", errmsg, url);
+        SYSERROR("download failed: %s: %s", errmsg, url);
         return -1;
     }
     chmod(path, 0755);

--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -20,7 +20,7 @@ int micromamba(const struct MicromambaInfo *info, char *command, ...) {
     }
 
     if (!info->download_dir || isempty(info->download_dir)) {
-        SYSERROR("%s", "micromamba inf->download_dir is NULL, or empty");
+        SYSERROR("micromamba inf->download_dir is NULL, or empty");
         return -1;
     }
 
@@ -65,12 +65,12 @@ int micromamba(const struct MicromambaInfo *info, char *command, ...) {
     va_list args;
     int cmd_len = snprintf(cmd, sizeof(cmd), "%s -r %s -p %s ", mmbin, info->conda_prefix, info->conda_prefix);
     if (cmd_len < 0) {
-        SYSERROR("%s", "Unable to build argument list for micromamba");
+        SYSERROR("Unable to build argument list for micromamba");
         va_end(args);
         return -1;
     }
     if ((size_t) cmd_len > sizeof(cmd)) {
-        SYSERROR("%s", "micromamba command truncated");
+        SYSERROR("micromamba command truncated");
         va_end(args);
         return -1;
     }
@@ -78,12 +78,12 @@ int micromamba(const struct MicromambaInfo *info, char *command, ...) {
     va_start(args, command);
     cmd_len = vsnprintf(cmd + strlen(cmd), sizeof(cmd) - strlen(cmd), command, args);
     if (cmd_len < 0) {
-        SYSERROR("%s", "Unable to append arguments to micromamba command");
+        SYSERROR("Unable to append arguments to micromamba command");
         va_end(args);
         return -1;
     }
     if ((size_t) cmd_len > sizeof(cmd)) {
-        SYSERROR("%s", "micromamba command truncated while appending arguments");
+        SYSERROR("micromamba command truncated while appending arguments");
         va_end(args);
         return -1;
     }
@@ -111,7 +111,7 @@ int python_exec(const char *args) {
 
     char *command = NULL;
     if (asprintf(&command, "%s%s", command_base, args) < 0 || !command) {
-        SYSERROR("%s", "Unable to allocate command string");
+        SYSERROR("Unable to allocate command string");
         return -1;
     }
     msg(STASIS_MSG_L3, "Executing: %s\n", command);
@@ -126,7 +126,7 @@ int pip_exec(const char *args) {
 
     char *command = NULL;
     if (asprintf(&command, "%s%s", command_base, args) < 0 || !command) {
-        SYSERROR("%s", "Unable to allocate command string");
+        SYSERROR("Unable to allocate command string");
         return -1;
     }
     msg(STASIS_MSG_L3, "Executing: %s\n", command);
@@ -646,7 +646,7 @@ int conda_env_create_from_uri(char *name, char *uri, char *python_version) {
     const char *fmt = "env create -n '%s' --file='%s'";
     char *env_command = NULL;
     if (asprintf(&env_command, fmt, name, tempfile) < 0 || !env_command) {
-        SYSERROR("%s", "unable to allocate environment command");
+        SYSERROR("unable to allocate environment command");
         return -1;
     }
 

--- a/src/lib/core/copy.c
+++ b/src/lib/core/copy.c
@@ -48,14 +48,14 @@ int copy2(const char *src, const char *dest, unsigned int op) {
     } else if (S_ISREG(src_stat.st_mode)) {
         char buf[STASIS_BUFSIZ] = {0};
         size_t bytes_read;
-        SYSDEBUG("%s", "Opening source file for reading");
+        SYSDEBUG("Opening source file for reading");
         FILE *fp1 = fopen(src, "rb");
         if (!fp1) {
             perror(src);
             return -1;
         }
 
-        SYSDEBUG("%s", "Opening destination file for writing");
+        SYSDEBUG("Opening destination file for writing");
         FILE *fp2 = fopen(dest, "w+b");
         if (!fp2) {
             perror(dest);
@@ -86,6 +86,6 @@ int copy2(const char *src, const char *dest, unsigned int op) {
         errno = EOPNOTSUPP;
         return -1;
     }
-    SYSDEBUG("%s", "Data copied");
+    SYSDEBUG("Data copied");
     return 0;
 }

--- a/src/lib/core/download.c
+++ b/src/lib/core/download.c
@@ -11,7 +11,7 @@ size_t download_writer(void *fp, size_t size, size_t nmemb, void *stream) {
 }
 
 long download(char *url, const char *filename, char **errmsg) {
-    SYSDEBUG("%s", "ARGS follow");
+    SYSDEBUG("ARGS follow");
     SYSDEBUG("url=%s", url);
     SYSDEBUG("filename=%s", filename);
     SYSDEBUG("errmsg=%s (NULL is OK)", *errmsg);
@@ -19,7 +19,7 @@ long download(char *url, const char *filename, char **errmsg) {
     char user_agent[STASIS_NAME_MAX] = {0};
     snprintf(user_agent, sizeof(user_agent), "stasis/%s", STASIS_VERSION);
 
-    SYSDEBUG("%s", "Setting timeout");
+    SYSDEBUG("Setting timeout");
     size_t timeout_default = 30L;
     size_t timeout = timeout_default;
     const char *timeout_str = getenv("STASIS_DOWNLOAD_TIMEOUT");
@@ -31,7 +31,7 @@ long download(char *url, const char *filename, char **errmsg) {
         }
     }
 
-    SYSDEBUG("%s", "Setting max_retries");
+    SYSDEBUG("Setting max_retries");
     const size_t max_retries_default = 5;
     size_t max_retries = max_retries_default;
     const char *max_retries_str = getenv("STASIS_DOWNLOAD_RETRY_MAX");
@@ -43,7 +43,7 @@ long download(char *url, const char *filename, char **errmsg) {
         }
     }
 
-    SYSDEBUG("%s", "Setting max_retry_seconds");
+    SYSDEBUG("Setting max_retry_seconds");
     const size_t max_retry_seconds_default = 3;
     size_t max_retry_seconds = max_retry_seconds_default;
     const char *max_retry_seconds_str = getenv("STASIS_DOWNLOAD_RETRY_SECONDS");
@@ -56,7 +56,7 @@ long download(char *url, const char *filename, char **errmsg) {
     }
 
 
-    SYSDEBUG("%s", "Initializing curl context");
+    SYSDEBUG("Initializing curl context");
     curl_global_init(CURL_GLOBAL_ALL);
     CURL *c = curl_easy_init();
     for (size_t retry = 0; retry < max_retries; retry++) {
@@ -64,7 +64,7 @@ long download(char *url, const char *filename, char **errmsg) {
             fprintf(stderr, "[RETRY %zu/%zu] %s: %s\n", retry + 1, max_retries, *errmsg, url);
         }
 
-        SYSDEBUG("%s", "Configuring curl");
+        SYSDEBUG("Configuring curl");
         curl_easy_setopt(c, CURLOPT_URL, url);
         curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, download_writer);
         FILE *fp = fopen(filename, "wb");
@@ -87,10 +87,10 @@ long download(char *url, const char *filename, char **errmsg) {
             SYSDEBUG("curl failed with code: %s", curl_easy_strerror(curl_code));
             const size_t errmsg_maxlen = 256;
             if (!*errmsg) {
-                SYSDEBUG("%s", "allocating memory for error message");
+                SYSDEBUG("allocating memory for error message");
                 *errmsg = calloc(errmsg_maxlen, sizeof(char));
                 if (!*errmsg) {
-                    SYSERROR("%s", "unable to allocate memory for error message");
+                    SYSERROR("unable to allocate memory for error message");
                     goto cleanup;
                 }
             }
@@ -102,7 +102,7 @@ long download(char *url, const char *filename, char **errmsg) {
         }
 
         cleanup:
-        SYSDEBUG("%s", "Cleaning up");
+        SYSDEBUG("Cleaning up");
         // Data written. Clean up.
         fclose(fp);
 

--- a/src/lib/core/environment.c
+++ b/src/lib/core/environment.c
@@ -414,19 +414,19 @@ void runtime_set(RuntimeEnv *env, const char *_key, char *_value) {
     const ssize_t key_offset = runtime_contains(env, _key);
     char *key = strdup(_key);
     if (!key) {
-        SYSERROR("%s", "unable to allocate memory for key");
+        SYSERROR("unable to allocate memory for key");
         exit(1);
     }
     char *value = runtime_expand_var(env, _value);
     if (!value) {
-        SYSERROR("%s", "unable to allocate memory for value");
+        SYSERROR("unable to allocate memory for value");
         exit(1);
     }
 
     lstrip(value);
     char *now = join((char *[]) {key, value, NULL}, sep);
     if (!now) {
-        SYSERROR("%s", "unable to allocate memory for join");
+        SYSERROR("unable to allocate memory for join");
         exit(1);
     }
 
@@ -448,7 +448,7 @@ void runtime_apply(RuntimeEnv *env) {
     for (size_t i = 0; i < strlist_count(env); i++) {
         char **pair = split(strlist_item(env, i), "=", 1);
         if (!pair) {
-            SYSERROR("%s", "unable to allocate memory for runtime_apply");
+            SYSERROR("unable to allocate memory for runtime_apply");
             return;
         }
         setenv(pair[0], pair[1], 1);

--- a/src/lib/core/include/core_mem.h
+++ b/src/lib/core/include/core_mem.h
@@ -2,7 +2,6 @@
 #ifndef STASIS_CORE_MEM_H
 #define STASIS_CORE_MEM_H
 
-#include "execpoint.h"
 #include "environment.h"
 #include "strlist.h"
 

--- a/src/lib/core/include/core_mem.h
+++ b/src/lib/core/include/core_mem.h
@@ -2,6 +2,7 @@
 #ifndef STASIS_CORE_MEM_H
 #define STASIS_CORE_MEM_H
 
+#include "execpoint.h"
 #include "environment.h"
 #include "strlist.h"
 

--- a/src/lib/core/include/core_message.h
+++ b/src/lib/core/include/core_message.h
@@ -2,18 +2,20 @@
 #ifndef STASIS_CORE_MESSAGE_H
 #define STASIS_CORE_MESSAGE_H
 
-#define SYSERROR(MSG, ...) do { \
-    fprintf(stderr, STASIS_COLOR_RED "ERROR: " STASIS_COLOR_RESET STASIS_COLOR_WHITE "%s:%d:%s()" STASIS_COLOR_RESET ":%s - ", path_basename(__FILE__), __LINE__, __FUNCTION__, (errno > 0) ? strerror(errno) : "info"); \
-    fprintf(stderr, MSG LINE_SEP, __VA_ARGS__); \
+#define SYSERROR(FMT, ...) do { \
+    log_print_error(EXECPOINT, (FMT), ##__VA_ARGS__); \
 } while (0)
 
-#ifdef DEBUG
-#define SYSDEBUG(MSG, ...) do { \
-    fprintf(stderr, STASIS_COLOR_BLUE "DEBUG: " STASIS_COLOR_RESET STASIS_COLOR_WHITE "%s:%d:%s()" STASIS_COLOR_RESET ": ", path_basename(__FILE__), __LINE__, __FUNCTION__); \
-    fprintf(stderr, MSG LINE_SEP, __VA_ARGS__); \
+#define SYSWARN(FMT, ...) do { \
+    log_print_warning(EXECPOINT, (FMT), ##__VA_ARGS__); \
 } while (0)
-#else
-#define SYSDEBUG(MSG, ...) do {} while (0)
-#endif
+
+#define SYSINFO(FMT, ...) do { \
+    log_print_info(EXECPOINT, (FMT), ##__VA_ARGS__); \
+} while (0)
+
+#define SYSDEBUG(FMT, ...) do { \
+    log_print_debug(EXECPOINT, (FMT), ##__VA_ARGS__); \
+} while (0)
 
 #endif //STASIS_CORE_MESSAGE_H

--- a/src/lib/core/include/log.h
+++ b/src/lib/core/include/log.h
@@ -1,0 +1,29 @@
+#ifndef STASIS_EXECPOINT_H
+#define STASIS_EXECPOINT_H
+
+#include <stdio.h>
+
+enum LogLevel {
+    LOG_LEVEL_WARN = 0,
+    LOG_LEVEL_INFO,
+    LOG_LEVEL_DEBUG,
+};
+extern enum LogLevel LOG_LEVEL;
+
+struct ExecPoint {
+    const int line;  // line number
+    const char *file;  // file name of origin
+    const char *function;  // function of origin
+};
+
+#define EXECPOINT (struct ExecPoint) {.line = __LINE__, .file = __FILE__, .function = __FUNCTION__}
+
+void log_print_error(struct ExecPoint ep, const char *fmt, ...);
+void log_print_warning(struct ExecPoint ep, const char *fmt, ...);
+void log_print_info(struct ExecPoint ep, const char *fmt, ...);
+void log_print_debug(struct ExecPoint ep, const char *fmt, ...);
+int log_msgv(FILE *stream, struct ExecPoint ep, const char *preface_color, const char *preface, const char *fmt, va_list ap);
+int log_msg(FILE *stream, struct ExecPoint ep, const char *preface_color, const char *preface, const char *fmt, ...);
+const char *log_get_level_str(void);
+
+#endif // STASIS_EXECPOINT_H

--- a/src/lib/core/include/str.h
+++ b/src/lib/core/include/str.h
@@ -9,8 +9,9 @@
 #include <string.h>
 #include <stdarg.h>
 #include <ctype.h>
-#include "relocation.h"
 #include "core.h"
+#include "log.h"
+#include "relocation.h"
 
 #define STASIS_SORT_ALPHA 1 << 0
 #define STASIS_SORT_NUMERIC 1 << 1

--- a/src/lib/core/include/str.h
+++ b/src/lib/core/include/str.h
@@ -18,6 +18,10 @@
 #define STASIS_SORT_LEN_ASCENDING 1 << 2
 #define STASIS_SORT_LEN_DESCENDING 1 << 3
 
+
+char *strdup_maybe_entry(const char * restrict s, struct ExecPoint ep, int exit_code);
+#define strdup_maybe(S) strdup_maybe_entry((S), EXECPOINT, 1)
+
 /**
  * Determine how many times the character `ch` appears in `sptr` string
  * @param sptr string to scan

--- a/src/lib/core/include/utils.h
+++ b/src/lib/core/include/utils.h
@@ -9,6 +9,7 @@
 #include <limits.h>
 #include <errno.h>
 #include "core.h"
+#include "log.h"
 #include "copy.h"
 #include "system.h"
 #include "strlist.h"

--- a/src/lib/core/ini.c
+++ b/src/lib/core/ini.c
@@ -464,7 +464,7 @@ int ini_write(struct INIFILE *ini, FILE **stream, unsigned mode) {
                     }
 
                     if (!render) {
-                        SYSERROR("%s", "rendered string value can never be NULL!\n");
+                        SYSERROR("rendered string value can never be NULL!");
                         return -1;
                     }
 

--- a/src/lib/core/junitxml.c
+++ b/src/lib/core/junitxml.c
@@ -79,7 +79,7 @@ static struct JUNIT_Failure *testcase_failure_from_attributes(struct StrList *at
             if (!strcmp(attr_name, "message")) {
                 result->message = strdup(attr_value);
                 if (!result->message) {
-                    SYSERROR("%s", "failed to allocate memory for testcase failure message");
+                    SYSERROR("failed to allocate memory for testcase failure message");
                     break;
                 }
             }
@@ -100,7 +100,7 @@ static struct JUNIT_Error *testcase_error_from_attributes(struct StrList *attrs)
             if (!strcmp(attr_name, "message")) {
                 result->message = strdup(attr_value);
                 if (!result->message) {
-                    SYSERROR("%s", "failed to allocate memory for testcase error message");
+                    SYSERROR("failed to allocate memory for testcase error message");
                     break;
                 }
             }
@@ -121,7 +121,7 @@ static struct JUNIT_Skipped *testcase_skipped_from_attributes(struct StrList *at
             if (!strcmp(attr_name, "message")) {
                 result->message = strdup(attr_value);
                 if (!result->message) {
-                    SYSERROR("%s", "failed to allocate memory for testcase skip message");
+                    SYSERROR("failed to allocate memory for testcase skip message");
                     break;
                 }
             }
@@ -133,7 +133,7 @@ static struct JUNIT_Skipped *testcase_skipped_from_attributes(struct StrList *at
 static struct JUNIT_Testcase *testcase_from_attributes(struct StrList *attrs) {
     struct JUNIT_Testcase *result = calloc(1, sizeof(*result));
     if(!result) {
-        SYSERROR("%s", "failed to allocate memory for testcase");
+        SYSERROR("failed to allocate memory for testcase");
         return NULL;
     }
     for (size_t x = 0; x < strlist_count(attrs); x += 2) {
@@ -143,14 +143,14 @@ static struct JUNIT_Testcase *testcase_from_attributes(struct StrList *attrs) {
             if (!strcmp(attr_name, "name")) {
                 result->name = strdup(attr_value);
                 if (!result->name) {
-                    SYSERROR("%s", "failed to allocate memory for testcase name");
+                    SYSERROR("failed to allocate memory for testcase name");
                     testcase_free(&result);
                     break;
                 }
             } else if (!strcmp(attr_name, "classname")) {
                 result->classname = strdup(attr_value);
                 if (!result->classname) {
-                    SYSERROR("%s", "failed to allocate memory for testcase class name");
+                    SYSERROR("failed to allocate memory for testcase class name");
                     testcase_free(&result);
                     break;
                 }
@@ -159,7 +159,7 @@ static struct JUNIT_Testcase *testcase_from_attributes(struct StrList *attrs) {
             } else if (!strcmp(attr_name, "message")) {
                 result->message = strdup(attr_value);
                 if (!result->message) {
-                    SYSERROR("%s", "failed to allocate memory for testcase message");
+                    SYSERROR("failed to allocate memory for testcase message");
                     testcase_free(&result);
                     break;
                 }

--- a/src/lib/core/log.c
+++ b/src/lib/core/log.c
@@ -1,0 +1,96 @@
+#include "core.h"
+#include "log.h"
+
+enum LogLevel LOG_LEVEL = LOG_LEVEL_WARN;
+
+void log_print_error(const struct ExecPoint ep, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log_msgv(stderr, ep, STASIS_COLOR_RED, "ERROR", fmt, ap);
+    va_end(ap);
+}
+
+void log_print_warning(const struct ExecPoint ep, const char *fmt, ...) {
+    if (LOG_LEVEL < LOG_LEVEL_WARN) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    log_msgv(stderr, ep, STASIS_COLOR_YELLOW, "WARNING", fmt, ap);
+    va_end(ap);
+}
+
+void log_print_info(const struct ExecPoint ep, const char *fmt, ...) {
+    if (LOG_LEVEL < LOG_LEVEL_INFO) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    log_msgv(stdout, ep, STASIS_COLOR_WHITE, "INFO", fmt, ap);
+    va_end(ap);
+}
+
+void log_print_debug(const struct ExecPoint ep, const char *fmt, ...) {
+    if (LOG_LEVEL < LOG_LEVEL_DEBUG) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    log_msgv(stderr, ep, STASIS_COLOR_BLUE, "DEBUG", fmt, ap);
+    va_end(ap);
+}
+
+int log_msgv(FILE *stream, const struct ExecPoint ep, const char *preface_color, const char *preface, const char *fmt, va_list ap) {
+    char header[STASIS_BUFSIZ] = {0};
+
+    int len = snprintf(header, sizeof(header),
+        STASIS_COLOR_RESET
+        "%s%s: "
+        STASIS_COLOR_RESET
+        STASIS_COLOR_WHITE
+        "%s:%d: %s(): "
+        STASIS_COLOR_RESET,
+        preface_color ? preface_color : STASIS_COLOR_RED,
+        preface ? preface : "UNKNOWN",
+        path_basename((char *) ep.file),
+        ep.line,
+        ep.function);
+    if (len >= (int) sizeof(header)) {
+        SYSERROR("header format truncated (%d >= %d)", len, (int) sizeof(header));
+        return len;
+    }
+
+    fprintf(stream, "%s", header);
+
+    va_list ap_out;
+    va_copy(ap_out, ap);
+    len = vfprintf(stream, fmt ? fmt : "NO MESSAGE", ap_out);
+    va_end(ap_out);
+    if (len < 0) {
+        SYSERROR("\nvfprintf failed");
+        return len;
+    }
+    fprintf(stderr, LINE_SEP);
+    return len;
+}
+
+int log_msg(FILE *stream, const struct ExecPoint ep, const char *preface_color, const char *preface, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    const int ret = log_msgv(stream, ep, preface_color, preface, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+const char *log_get_level_str(void) {
+    switch (LOG_LEVEL) {
+        case LOG_LEVEL_WARN:
+            return "WARN";
+        case LOG_LEVEL_INFO:
+            return "INFO";
+        case LOG_LEVEL_DEBUG:
+        default:
+            // Anything higher is still DEBUG
+            return "DEBUG";
+    }
+}

--- a/src/lib/core/multiprocessing.c
+++ b/src/lib/core/multiprocessing.c
@@ -158,7 +158,7 @@ static int mp_task_fork(struct MultiProcessingPool *pool, struct MultiProcessing
 }
 
 struct MultiProcessingTask *mp_pool_task(struct MultiProcessingPool *pool, const char *ident, char *working_dir, char *cmd) {
-    SYSDEBUG("%s", "Finding next available slot");
+    SYSDEBUG("Finding next available slot");
     struct MultiProcessingTask *slot = mp_pool_next_available(pool);
     if (pool->num_used != pool->num_alloc) {
         SYSDEBUG("Using slot %zu of %zu", pool->num_used, pool->num_alloc);
@@ -196,14 +196,14 @@ struct MultiProcessingTask *mp_pool_task(struct MultiProcessingPool *pool, const
 
     t_name = xmkstemp(&tp, "w");
     if (!t_name) {
-        SYSERROR("%s", "Failed to create temporary file name");
+        SYSERROR("Failed to create temporary file name");
         if (tp) {
             fclose(tp);
         }
         return NULL;
     }
     if (!tp) {
-        SYSERROR("%s", "Failed to create temporary file");
+        SYSERROR("Failed to create temporary file");
         guard_free(t_name);
         return NULL;
     }

--- a/src/lib/core/relocation.c
+++ b/src/lib/core/relocation.c
@@ -36,7 +36,7 @@ int replace_text(char *original, const char *target, const char *replacement, un
 
     if (original_len > sizeof(buffer)) {
         errno = EINVAL;
-        SYSERROR("The original string is larger than buffer: %zu > %zu\n", original_len, sizeof(buffer));
+        SYSERROR("The original string is larger than buffer: %zu > %zu", original_len, sizeof(buffer));
         return -1;
     }
 

--- a/src/lib/core/semaphore.c
+++ b/src/lib/core/semaphore.c
@@ -72,7 +72,7 @@ int semaphore_post(struct Semaphore *s) {
 
 void semaphore_destroy(struct Semaphore *s) {
     if (!s) {
-        SYSDEBUG("%s", "would have crashed");
+        SYSDEBUG("would have crashed");
         return;
     }
     SYSDEBUG("%s", s->name);

--- a/src/lib/core/str.c
+++ b/src/lib/core/str.c
@@ -588,7 +588,7 @@ char **strdup_array(char **array) {
     // Create new array
     result = calloc(elems + 1, sizeof(*result));
     if (!result) {
-        SYSERROR("%s", "could not allocate memory for result array");
+        SYSERROR("could not allocate memory for result array");
         return NULL;
     }
     for (size_t i = 0; i < elems; i++) {

--- a/src/lib/core/str.c
+++ b/src/lib/core/str.c
@@ -4,6 +4,22 @@
 #include <unistd.h>
 #include "str.h"
 
+
+
+char *strdup_maybe_entry(const char * restrict s, const struct ExecPoint ep, const int exit_code) {
+    // USE MACRO FROM str.h: strdup_maybe()
+    if (s != NULL) {
+        char *x = strdup(s);
+        if (!x) {
+            SYSERROR("unable to duplicate string");
+            log_print_error(ep, "out of memory");
+            exit(exit_code);
+        }
+        return x;
+    }
+    return NULL;
+}
+
 int num_chars(const char *sptr, int ch) {
     int result = 0;
     for (int i = 0; sptr[i] != '\0'; i++) {

--- a/src/lib/core/template.c
+++ b/src/lib/core/template.c
@@ -20,7 +20,7 @@ struct tplfunc_frame *tpl_pool_func[1024] = {0};
 unsigned tpl_pool_func_used = 0;
 
 extern void tpl_reset() {
-    SYSDEBUG("%s", "Resetting template engine");
+    SYSDEBUG("Resetting template engine");
     tpl_free();
     tpl_pool_used = 0;
     tpl_pool_func_used = 0;
@@ -29,13 +29,13 @@ extern void tpl_reset() {
 void tpl_register_func(char *key, void *tplfunc_ptr, int argc, void *data_in) {
     struct tplfunc_frame *frame = calloc(1, sizeof(*frame));
     if (!frame) {
-        SYSERROR("%s", "unable to allocate memory for function frame");
+        SYSERROR("unable to allocate memory for function frame");
         exit(1);
     }
 
     frame->key = strdup(key);
     if (!frame->key) {
-        SYSERROR("%s", "unable to allocate memory for function frame key");
+        SYSERROR("unable to allocate memory for function frame key");
         exit(1);
     }
     frame->argc = argc;
@@ -52,12 +52,12 @@ int tpl_key_exists(char *key) {
     for (size_t i = 0; i < tpl_pool_used; i++) {
         if (tpl_pool[i]->key) {
             if (!strcmp(tpl_pool[i]->key, key)) {
-                SYSDEBUG("%s", "YES");
+                SYSDEBUG("YES");
                 return true;
             }
         }
     }
-    SYSDEBUG("%s", "NO");
+    SYSDEBUG("NO");
     return false;
 }
 
@@ -76,17 +76,17 @@ void tpl_register(char *key, char **ptr) {
             }
         }
         replacing = 1;
-        SYSDEBUG("%s", "Item will be replaced");
+        SYSDEBUG("Item will be replaced");
     } else {
-        SYSDEBUG("%s", "Creating new item");
+        SYSDEBUG("Creating new item");
         item = calloc(1, sizeof(*item));
         if (!item) {
-            SYSERROR("%s", "unable to allocate memory for new item");
+            SYSERROR("unable to allocate memory for new item");
             exit(1);
         }
         item->key = strdup(key);
         if (!key) {
-            SYSERROR("%s", "unable to allocate memory for new key");
+            SYSERROR("unable to allocate memory for new key");
             exit(1);
         }
     }
@@ -186,7 +186,7 @@ char *tpl_render(char *str) {
             }
 
             // Read key name
-            SYSDEBUG("%s", "Reading key");
+            SYSDEBUG("Reading key");
             size_t key_len = 0;
             while (isalnum(pos[off]) || pos[off] != '}') {
                 if (isspace(pos[off]) || isblank(pos[off])) {
@@ -207,10 +207,10 @@ char *tpl_render(char *str) {
             int do_func = 0;
             if (type_stop) {
                 if (!strncmp(key, "env", type_stop - key)) {
-                    SYSDEBUG("%s", "Will render as value of environment variable");
+                    SYSDEBUG("Will render as value of environment variable");
                     do_env = 1;
                 } else if (!strncmp(key, "func", type_stop - key)) {
-                    SYSDEBUG("%s", "Will render as output from function");
+                    SYSDEBUG("Will render as output from function");
                     do_func = 1;
                 }
             }
@@ -327,7 +327,7 @@ int tpl_render_to_file(char *str, const char *filename) {
     // Write rendered string to file
     fprintf(fp, "%s", result);
     fclose(fp);
-    SYSDEBUG("%s", "Rendered successfully");
+    SYSDEBUG("Rendered successfully");
 
     guard_free(result);
     return 0;

--- a/src/lib/core/utils.c
+++ b/src/lib/core/utils.c
@@ -466,18 +466,18 @@ void msg(unsigned type, char *fmt, ...) {
     }
 
     if (fprintf(stream, "%s", header) < 0) {
-        SYSERROR("%s", "unable to write message header to stream");
+        SYSERROR("unable to write message header to stream");
         return;
     }
 
     const int len = vfprintf(stream, fmt, args);
     if (len < 0) {
-        SYSERROR("%s", "unable to write message to stream");
+        SYSERROR("unable to write message to stream");
         return;
     }
 
     if (fprintf(stream, "%s", STASIS_COLOR_RESET) < 0) {
-        SYSERROR("%s", "unable to write message footer to stream");
+        SYSERROR("unable to write message footer to stream");
         return;
     }
     va_end(args);
@@ -670,7 +670,7 @@ int fix_tox_conf(const char *filename, char **result, size_t maxlen) {
     // Create new temporary tox configuration file
     char *tempfile = xmkstemp(&fptemp, "w+");
     if (!tempfile) {
-        SYSERROR("%s", "unable to create temporary file");
+        SYSERROR("unable to create temporary file");
         return -1;
     }
 
@@ -828,7 +828,7 @@ struct StrList *listdir(const char *path) {
         }
         char *fullpath = join_ex("/", path, rec->d_name, NULL);
         if (!fullpath) {
-            SYSERROR("%s", "Unable to allocate bytes to construct full path");
+            SYSERROR("Unable to allocate bytes to construct full path");
             guard_strlist_free(&node);
             closedir(dp);
             return NULL;
@@ -878,13 +878,13 @@ char *find_version_spec(char *str) {
 
 int env_manipulate_pathstr(const char *key, char *path, int mode) {
     if (isempty(path)) {
-        SYSERROR("%s", "New PATH element cannot be zero-length or NULL");
+        SYSERROR("New PATH element cannot be zero-length or NULL");
         return -1;
     }
 
     const char *system_path_old = getenv("PATH");
     if (!system_path_old) {
-        SYSERROR("%s", "Unable to read PATH");
+        SYSERROR("Unable to read PATH");
         return -1;
     }
 
@@ -897,7 +897,7 @@ int env_manipulate_pathstr(const char *key, char *path, int mode) {
     }
 
     if (!system_path_new) {
-        SYSERROR("%s", "Unable to allocate memory to update PATH");
+        SYSERROR("Unable to allocate memory to update PATH");
         return -1;
     }
 
@@ -986,7 +986,7 @@ int grow(const size_t size_new, size_t *size_orig, char **data) {
     }
     if (size_new >= *size_orig) {
         const size_t new_size = *size_orig + size_new + 1;
-        SYSDEBUG("template data buffer new size: %zu\n", new_size);
+        SYSDEBUG("template data buffer new size: %zu", new_size);
 
         char *tmp = realloc(*data, new_size);
         if (!tmp) {
@@ -1176,7 +1176,7 @@ int get_random_bytes(char *result, size_t maxlen) {
     if (filename != NULL) {
         fp = fopen(filename, "rb");
         if (!fp) {
-            SYSERROR("%s", "unable to open random generator");
+            SYSERROR("unable to open random generator");
             return -1;
         }
     }
@@ -1189,7 +1189,7 @@ int get_random_bytes(char *result, size_t maxlen) {
             ch = rand() % 255;
         }
         if (fp && ferror(fp)) {
-            SYSERROR("%s", "unable to read from random generator");
+            SYSERROR("unable to read from random generator");
             fclose(fp);
             return -1;
         }

--- a/src/lib/core/wheel.c
+++ b/src/lib/core/wheel.c
@@ -70,13 +70,13 @@ static ssize_t wheel_parse_wheel(struct Wheel * pkg, const char * data) {
         if (pair) {
             char *key = strdup(strip(pair[0]));
             if (!key) {
-                SYSERROR("%s", "could not allocate memory for pair wheel key");
+                SYSERROR("could not allocate memory for pair wheel key");
                 return -1;
             }
 
             char *value = strdup(lstrip(pair[1]));
             if (!value) {
-                SYSERROR("%s", "could not allocate memory for wheel value");
+                SYSERROR("could not allocate memory for wheel value");
                 guard_free(key);
                 return -1;
             }

--- a/src/lib/delivery/delivery.c
+++ b/src/lib/delivery/delivery.c
@@ -1,4 +1,5 @@
 #include "delivery.h"
+#include "conda.h"
 
 static char *strdup_maybe(const char * restrict s) {
     if (s != NULL) {

--- a/src/lib/delivery/delivery.c
+++ b/src/lib/delivery/delivery.c
@@ -1,17 +1,6 @@
 #include "delivery.h"
 #include "conda.h"
 
-static char *strdup_maybe(const char * restrict s) {
-    if (s != NULL) {
-        char *x = strdup(s);
-        if (!x) {
-            SYSERROR("%s", "strdup failed");
-            exit(1);
-        }
-        return x;
-    }
-    return NULL;
-}
 struct Delivery *delivery_duplicate(const struct Delivery *ctx) {
     struct Delivery *result = calloc(1, sizeof(*result));
     if (!result) {

--- a/src/lib/delivery/delivery.c
+++ b/src/lib/delivery/delivery.c
@@ -63,20 +63,20 @@ struct Delivery *delivery_duplicate(const struct Delivery *ctx) {
     memcpy(&result->rules.content, &ctx->rules.content, sizeof(ctx->rules.content));
 
     if (ctx->rules._handle) {
-        SYSDEBUG("%s", "duplicating INIFILE handle - BEGIN");
+        SYSDEBUG("duplicating INIFILE handle - BEGIN");
         result->rules._handle = malloc(sizeof(*result->rules._handle));
         if (!result->rules._handle) {
-            SYSERROR("%s", "unable to allocate space for INIFILE handle");
+            SYSERROR("unable to allocate space for INIFILE handle");
             return NULL;
         }
         result->rules._handle->section = malloc(ctx->rules._handle->section_count * sizeof(**ctx->rules._handle->section));
         if (!result->rules._handle->section) {
             guard_free(result->rules._handle);
-            SYSERROR("%s", "unable to allocate space for INIFILE section");
+            SYSERROR("unable to allocate space for INIFILE section");
             return NULL;
         }
         memcpy(result->rules._handle, &ctx->rules._handle, sizeof(*ctx->rules._handle));
-        SYSDEBUG("%s", "duplicating INIFILE handle - END");
+        SYSDEBUG("duplicating INIFILE handle - END");
     }
 
     // Runtime
@@ -112,7 +112,7 @@ struct Delivery *delivery_duplicate(const struct Delivery *ctx) {
     if (ctx->system.platform) {
         result->system.platform = malloc(DELIVERY_PLATFORM_MAX * sizeof(*result->system.platform));
         if (!result->system.platform) {
-            SYSERROR("%s", "unable to allocate space for system platform array");
+            SYSERROR("unable to allocate space for system platform array");
             return NULL;
         }
         for (size_t i = 0; i < DELIVERY_PLATFORM_MAX; i++) {
@@ -365,7 +365,7 @@ void delivery_defer_packages(struct Delivery *ctx, int type) {
         deferred = ctx->conda.pip_packages_defer;
         strncpy(mode, "pip", sizeof(mode) - 1);
     } else {
-        SYSERROR("BUG: type %d does not map to a supported package manager!\n", type);
+        SYSERROR("BUG: type %d does not map to a supported package manager!", type);
         exit(1);
     }
     mode[sizeof(mode) - 1] = '\0';

--- a/src/lib/delivery/delivery_artifactory.c
+++ b/src/lib/delivery/delivery_artifactory.c
@@ -5,7 +5,7 @@ int delivery_init_artifactory(struct Delivery *ctx) {
     char dest[PATH_MAX] = {0};
     char filepath[PATH_MAX] = {0};
 
-    SYSDEBUG("%s", "Initializing artifactory tools");
+    SYSDEBUG("Initializing artifactory tools");
     snprintf(dest, sizeof(dest), "%s/bin", ctx->storage.tools_dir);
     SYSDEBUG("dest=%s", dest);
     snprintf(filepath, sizeof(dest), "%s/bin/jf", ctx->storage.tools_dir);
@@ -17,7 +17,7 @@ int delivery_init_artifactory(struct Delivery *ctx) {
         goto delivery_init_artifactory_envsetup;
     }
 
-    SYSDEBUG("%s", "Assign platform");
+    SYSDEBUG("Assign platform");
     char *platform = ctx->system.platform[DELIVERY_PLATFORM];
     msg(STASIS_MSG_L3, "Downloading %s for %s %s\n", globals.jfrog.remote_filename, platform, ctx->system.arch);
     if ((status = artifactory_download_cli(dest,
@@ -200,7 +200,7 @@ int delivery_series_sync(struct Delivery *ctx) {
 
     char *r_fmt = strdup(ctx->rules.release_fmt);
     if (!r_fmt) {
-        SYSERROR("%s", "Unable to allocate bytes for release format string");
+        SYSERROR("Unable to allocate bytes for release format string");
         return -1;
     }
 
@@ -228,7 +228,7 @@ int delivery_series_sync(struct Delivery *ctx) {
                  ctx->meta.mission,
                  ctx->info.build_name,
                  release_pattern) < 0) {
-        SYSERROR("%s", "Unable to allocate bytes for remote directory path");
+        SYSERROR("Unable to allocate bytes for remote directory path");
         guard_free(release_pattern);
         return -1;
     }
@@ -236,7 +236,7 @@ int delivery_series_sync(struct Delivery *ctx) {
 
     char *dest_dir = NULL;
     if (asprintf(&dest_dir, "%s/{1}", ctx->storage.output_dir) < 0) {
-        SYSERROR("%s", "Unable to allocate bytes for destination directory path");
+        SYSERROR("Unable to allocate bytes for destination directory path");
         return -1;
     }
 

--- a/src/lib/delivery/delivery_build.c
+++ b/src/lib/delivery/delivery_build.c
@@ -185,17 +185,17 @@ int manylinux_exec(const char *image, const char *script, const char *copy_to_co
     // setup
 
     if (get_random_bytes(suffix, sizeof(suffix))) {
-        SYSERROR("%s", "unable to acquire value from random generator");
+        SYSERROR("unable to acquire value from random generator");
         goto manylinux_fail;
     }
 
     if (asprintf(&container_name, "manylinux_build_%d_%zd_%s", uid, time(NULL), suffix) < 0) {
-        SYSERROR("%s", "unable to allocate memory for container name");
+        SYSERROR("unable to allocate memory for container name");
         goto manylinux_fail;
     }
 
     if (asprintf(&args, "--name %s -w /build -v %s:/build", container_name, container_name) < 0) {
-        SYSERROR("%s", "unable to allocate memory for docker arguments");
+        SYSERROR("unable to allocate memory for docker arguments");
         goto manylinux_fail;
     }
 
@@ -205,77 +205,77 @@ int manylinux_exec(const char *image, const char *script, const char *copy_to_co
     }
 
     if (asprintf(&nop_create_command, "run --name nop_%s -v %s:/build busybox", container_name, container_name) < 0) {
-        SYSERROR("%s", "unable to allocate memory for nop container command");
+        SYSERROR("unable to allocate memory for nop container command");
         goto manylinux_fail;
     }
 
     if (asprintf(&source_copy_command, "cp %s nop_%s:/build", copy_to_container_dir, container_name) < 0) {
-        SYSERROR("%s", "unable to allocate memory for source copy command");
+        SYSERROR("unable to allocate memory for source copy command");
         goto manylinux_fail;
     }
 
     if (asprintf(&nop_rm_command, "rm nop_%s", container_name) < 0) {
-        SYSERROR("%s", "unable to allocate memory for nop container command");
+        SYSERROR("unable to allocate memory for nop container command");
         goto manylinux_fail;
     }
 
     if (asprintf(&wheel_paths_filename, "%s/wheel_paths_%s.txt", globals.tmpdir, container_name) < 0) {
-        SYSERROR("%s", "unable to allocate memory for wheel paths file name");
+        SYSERROR("unable to allocate memory for wheel paths file name");
         goto manylinux_fail;
     }
 
     if (asprintf(&find_command, "run --rm -t -v %s:/build busybox sh -c 'find %s -name \"*.whl\"' > %s", container_name, copy_from_container_dir, wheel_paths_filename) < 0) {
-        SYSERROR("%s", "unable to allocate memory for find command");
+        SYSERROR("unable to allocate memory for find command");
         goto manylinux_fail;
     }
 
     // execute
 
     if (docker_exec(nop_create_command, 0)) {
-        SYSERROR("%s", "docker nop container creation failed");
+        SYSERROR("docker nop container creation failed");
         goto manylinux_fail;
     }
 
     if (docker_exec(source_copy_command, 0)) {
-        SYSERROR("%s", "docker source copy operation failed");
+        SYSERROR("docker source copy operation failed");
         goto manylinux_fail;
     }
 
     if (docker_exec(nop_rm_command, STASIS_DOCKER_QUIET)) {
-        SYSERROR("%s", "docker nop container removal failed");
+        SYSERROR("docker nop container removal failed");
         goto manylinux_fail;
     }
 
     if (docker_script(image, args, (char *) script, 0)) {
-        SYSERROR("%s", "manylinux execution failed");
+        SYSERROR("manylinux execution failed");
         goto manylinux_fail;
     }
 
     if (docker_exec(find_command, 0)) {
-        SYSERROR("%s", "docker find command failed");
+        SYSERROR("docker find command failed");
         goto manylinux_fail;
     }
 
     struct StrList *wheel_paths = strlist_init();
     if (!wheel_paths) {
-        SYSERROR("%s", "wheel_paths not initialized");
+        SYSERROR("wheel_paths not initialized");
         goto manylinux_fail;
     }
 
     if (strlist_append_file(wheel_paths, wheel_paths_filename, read_without_line_endings)) {
-        SYSERROR("%s", "wheel_paths append failed");
+        SYSERROR("wheel_paths append failed");
         goto manylinux_fail;
     }
 
     for (size_t i = 0; i < strlist_count(wheel_paths); i++) {
         const char *item = strlist_item(wheel_paths, i);
         if (asprintf(&copy_command, "cp %s:%s %s", container_name, item, copy_to_host_dir) < 0) {
-            SYSERROR("%s", "unable to allocate memory for docker copy command");
+            SYSERROR("unable to allocate memory for docker copy command");
             goto manylinux_fail;
         }
 
         if (docker_exec(copy_command, 0)) {
-            SYSERROR("%s", "docker copy operation failed");
+            SYSERROR("docker copy operation failed");
             goto manylinux_fail;
         }
         guard_free(copy_command);
@@ -293,21 +293,21 @@ int manylinux_exec(const char *image, const char *script, const char *copy_to_co
         // Keep going on failure unless memory related.
         // We don't want build debris everywhere.
         if (asprintf(&rm_command, "rm %s", container_name) < 0) {
-            SYSERROR("%s", "unable to allocate memory for rm command");
+            SYSERROR("unable to allocate memory for rm command");
             goto late_fail;
         }
 
         if (docker_exec(rm_command, STASIS_DOCKER_QUIET)) {
-            SYSERROR("%s", "docker container removal operation failed");
+            SYSERROR("docker container removal operation failed");
         }
 
         if (asprintf(&volume_rm_command, "volume rm -f %s", container_name) < 0) {
-            SYSERROR("%s", "unable to allocate memory for docker volume removal command");
+            SYSERROR("unable to allocate memory for docker volume removal command");
             goto late_fail;
         }
 
         if (docker_exec(volume_rm_command, STASIS_DOCKER_QUIET)) {
-            SYSERROR("%s", "docker volume removal operation failed");
+            SYSERROR("docker volume removal operation failed");
         }
     }
 
@@ -331,7 +331,7 @@ int delivery_build_wheels_manylinux(struct Delivery *ctx, const char *outdir) {
 
     const char *manylinux_image = globals.wheel_builder_manylinux_image;
     if (!manylinux_image) {
-        SYSERROR("%s", "manylinux_image not initialized");
+        SYSERROR("manylinux_image not initialized");
         return -1;
     }
 
@@ -349,7 +349,7 @@ int delivery_build_wheels_manylinux(struct Delivery *ctx, const char *outdir) {
     char *script = NULL;
     if (asprintf(&script, script_fmt,
         meta->python, meta->python) < 0) {
-        SYSERROR("%s", "unable to allocate memory for build script");
+        SYSERROR("unable to allocate memory for build script");
         return -1;
     }
     manylinux_build_status = manylinux_exec(
@@ -410,7 +410,7 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
 
                 snprintf(srcdir, sizeof(srcdir), "%s/%s", ctx->storage.build_sources_dir, ctx->tests->test[i]->name);
                 if (git_clone(&proc, ctx->tests->test[i]->repository, srcdir, ctx->tests->test[i]->version)) {
-                    SYSERROR("Unable to checkout tag '%s' for package '%s' from repository '%s'\n",
+                    SYSERROR("Unable to checkout tag '%s' for package '%s' from repository '%s'",
                     ctx->tests->test[i]->version, ctx->tests->test[i]->name, ctx->tests->test[i]->repository);
                     return NULL;
                 }
@@ -464,13 +464,13 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                     } else if (use_builder_build || use_builder_cibuildwheel) {
                         if (use_builder_build) {
                             if (asprintf(&cmd, "-m build -w -o %s", outdir) < 0) {
-                                SYSERROR("%s", "Unable to allocate memory for build command");
+                                SYSERROR("Unable to allocate memory for build command");
                                 return NULL;
                             }
                         } else if (use_builder_cibuildwheel) {
                             if (asprintf(&cmd, "-m cibuildwheel --output-dir %s --only cp%s-manylinux_%s",
                                 outdir, ctx->meta.python_compact, ctx->system.arch) < 0) {
-                                SYSERROR("%s", "Unable to allocate memory for cibuildwheel command");
+                                SYSERROR("Unable to allocate memory for cibuildwheel command");
                                 return NULL;
                             }
                         }

--- a/src/lib/delivery/delivery_build.c
+++ b/src/lib/delivery/delivery_build.c
@@ -1,4 +1,8 @@
+#include <fnmatch.h>
+
 #include "delivery.h"
+#include "conda.h"
+#include "recipe.h"
 
 int delivery_build_recipes(struct Delivery *ctx) {
     for (size_t i = 0; i < ctx->tests->num_used; i++) {

--- a/src/lib/delivery/delivery_conda.c
+++ b/src/lib/delivery/delivery_conda.c
@@ -46,7 +46,7 @@ int delivery_get_conda_installer(struct Delivery *ctx, char *installer_url) {
         long fetch_status = download(installer_url, script_path, &errmsg);
         if (HTTP_ERROR(fetch_status) || fetch_status < 0) {
             // download failed
-            SYSERROR("download failed: %s: %s\n", errmsg, installer_url);
+            SYSERROR("download failed: %s: %s", errmsg, installer_url);
             guard_free(errmsg);
             return -1;
         }

--- a/src/lib/delivery/delivery_conda.c
+++ b/src/lib/delivery/delivery_conda.c
@@ -1,4 +1,5 @@
 #include "delivery.h"
+#include "conda.h"
 
 void delivery_get_conda_installer_url(struct Delivery *ctx, char *result, size_t maxlen) {
     int len = 0;

--- a/src/lib/delivery/delivery_export.c
+++ b/src/lib/delivery/delivery_export.c
@@ -7,7 +7,7 @@ static void delivery_export_configuration(const struct Delivery *ctx) {
     SYSDEBUG("Entering configuration directory: %s", ctx->storage.delivery_dir);
     if (!pushd(ctx->storage.cfgdump_dir)) {
         char filename[PATH_MAX] = {0};
-        SYSDEBUG("%s", "Populating filename");
+        SYSDEBUG("Populating filename");
         snprintf(filename, sizeof(filename), "%s.ini", ctx->info.release_name);
         SYSDEBUG("filename: %s", filename);
 
@@ -23,9 +23,9 @@ static void delivery_export_configuration(const struct Delivery *ctx) {
         fclose(spec);
         SYSDEBUG("%s: closing", filename);
 
-        SYSDEBUG("%s", "Zeroing filename");
+        SYSDEBUG("Zeroing filename");
         memset(filename, 0, sizeof(filename));
-        SYSDEBUG("%s", "Populating rendered filename");
+        SYSDEBUG("Populating rendered filename");
         snprintf(filename, sizeof(filename), "%s-rendered.ini", ctx->info.release_name);
         SYSDEBUG("filename: %s", filename);
 

--- a/src/lib/delivery/delivery_export.c
+++ b/src/lib/delivery/delivery_export.c
@@ -1,4 +1,5 @@
 #include "delivery.h"
+#include "conda.h"
 
 static void delivery_export_configuration(const struct Delivery *ctx) {
     msg(STASIS_MSG_L2, "Exporting delivery configuration\n");

--- a/src/lib/delivery/delivery_init.c
+++ b/src/lib/delivery/delivery_init.c
@@ -24,13 +24,13 @@ int delivery_init_tmpdir(struct Delivery *ctx) {
         tmpdir = strdup(x);
         if (!tmpdir) {
             // memory error
-            SYSERROR("%s", "unable to allocate tmpdir");
+            SYSERROR("unable to allocate tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
     } else {
         tmpdir = strdup("/tmp/stasis");
         if (!tmpdir) {
-            SYSERROR("%s", "unable to allocate tmpdir");
+            SYSERROR("unable to allocate tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
         //need_setenv = 1;
@@ -39,7 +39,7 @@ int delivery_init_tmpdir(struct Delivery *ctx) {
     if (!ctx->storage.tmpdir) {
         ctx->storage.tmpdir = strdup(tmpdir);
         if (!ctx->storage.tmpdir) {
-            SYSERROR("%s", "unable to allocate ctx->storage.tmpdir");
+            SYSERROR("unable to allocate ctx->storage.tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
     } else {
@@ -47,7 +47,7 @@ int delivery_init_tmpdir(struct Delivery *ctx) {
         guard_free(tmpdir);
         tmpdir = strdup(ctx->storage.tmpdir);
         if (!tmpdir) {
-            SYSERROR("%s", "unable to allocate tmpdir");
+            SYSERROR("unable to allocate tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
     }
@@ -85,7 +85,7 @@ int delivery_init_tmpdir(struct Delivery *ctx) {
     if (!globals.tmpdir || strcmp(globals.tmpdir, ctx->storage.tmpdir) != 0) {
         globals.tmpdir = strdup(tmpdir);
         if (!globals.tmpdir) {
-            SYSERROR("%s", "unable to allocate globals.tmpdir");
+            SYSERROR("unable to allocate globals.tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
     }
@@ -93,7 +93,7 @@ int delivery_init_tmpdir(struct Delivery *ctx) {
     if (!ctx->storage.tmpdir) {
         ctx->storage.tmpdir = strdup(globals.tmpdir);
         if (!ctx->storage.tmpdir) {
-            SYSERROR("%s", "unable to allocate globals.tmpdir");
+            SYSERROR("unable to allocate globals.tmpdir");
             goto l_delivery_init_tmpdir_fatal;
         }
     }
@@ -185,7 +185,7 @@ void delivery_init_dirs_stage1(struct Delivery *ctx) {
 }
 
 int delivery_init_platform(struct Delivery *ctx) {
-    SYSDEBUG("%s", "Setting architecture");
+    SYSDEBUG("Setting architecture");
     char archsuffix[20];
     struct utsname uts;
     if (uname(&uts)) {
@@ -195,7 +195,7 @@ int delivery_init_platform(struct Delivery *ctx) {
 
     ctx->system.platform = calloc(DELIVERY_PLATFORM_MAX + 1, sizeof(*ctx->system.platform));
     if (!ctx->system.platform) {
-        SYSERROR("Unable to allocate %d records for platform array\n", DELIVERY_PLATFORM_MAX);
+        SYSERROR("Unable to allocate %d records for platform array", DELIVERY_PLATFORM_MAX);
         return -1;
     }
     for (size_t i = 0; i < DELIVERY_PLATFORM_MAX; i++) {
@@ -215,7 +215,7 @@ int delivery_init_platform(struct Delivery *ctx) {
     }
     archsuffix[sizeof(archsuffix) - 1] = '\0';
 
-    SYSDEBUG("%s", "Setting platform");
+    SYSDEBUG("Setting platform");
     strncpy(ctx->system.platform[DELIVERY_PLATFORM], uts.sysname, DELIVERY_PLATFORM_MAXLEN - 1);
     if (!strcmp(ctx->system.platform[DELIVERY_PLATFORM], "Darwin")) {
         snprintf(ctx->system.platform[DELIVERY_PLATFORM_CONDA_SUBDIR], DELIVERY_PLATFORM_MAXLEN, "osx-%s", archsuffix);
@@ -346,22 +346,22 @@ int bootstrap_build_info(struct Delivery *ctx) {
     local._stasis_ini_fp.delivery = ini_open(ctx->_stasis_ini_fp.delivery_path);
 
     if (delivery_init_platform(&local)) {
-        SYSDEBUG("%s", "delivery_init_platform failed");
+        SYSDEBUG("delivery_init_platform failed");
         delivery_free(&local);
         return -1;
     }
     if (populate_delivery_cfg(&local, INI_READ_RENDER)) {
-        SYSDEBUG("%s", "populate_delivery_cfg failed");
+        SYSDEBUG("populate_delivery_cfg failed");
         delivery_free(&local);
         return -1;
     }
     if (populate_delivery_ini(&local, INI_READ_RENDER)) {
-        SYSDEBUG("%s", "populate_delivery_ini failed");
+        SYSDEBUG("populate_delivery_ini failed");
         delivery_free(&local);
         return -1;
     }
     if (populate_info(&local)) {
-        SYSDEBUG("%s", "populate_info failed");
+        SYSDEBUG("populate_info failed");
         delivery_free(&local);
         return -1;
     }
@@ -379,7 +379,7 @@ int bootstrap_build_info(struct Delivery *ctx) {
     memcpy(ctx->info.time_info, local.info.time_info, sizeof(*local.info.time_info));
     ctx->info.time_now = local.info.time_now;
     ctx->info.time_str_epoch = strdup(local.info.time_str_epoch);
-    SYSDEBUG("%s", "delivery_free local resources");
+    SYSDEBUG("delivery_free local resources");
     delivery_free(&local);
     return 0;
 }

--- a/src/lib/delivery/delivery_init.c
+++ b/src/lib/delivery/delivery_init.c
@@ -1,3 +1,6 @@
+#include <fnmatch.h>
+#include <sys/utsname.h>
+
 #include "delivery.h"
 
 int has_mount_flags(const char *mount_point, const unsigned long flags) {

--- a/src/lib/delivery/delivery_install.c
+++ b/src/lib/delivery/delivery_install.c
@@ -143,11 +143,11 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
     int status = 0;
 
     if (isempty((char *) env_name)) {
-        SYSERROR("%s", "environment name cannot be NULL or empty");
+        SYSERROR("environment name cannot be NULL or empty");
         return -1;
     }
     if (isempty((char *) name)) {
-        SYSERROR("%s", "name cannot be NULL or empty");
+        SYSERROR("name cannot be NULL or empty");
         return -1;
     }
 
@@ -164,14 +164,14 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
 
     struct StrList *lines = strlist_init();
     if (!lines) {
-        SYSERROR("%s", "unable to allocate memory for installed package list");
+        SYSERROR("unable to allocate memory for installed package list");
         guard_free(output);
         status = -1;
         goto cleanup;
     }
 
     if (strlist_append_tokenize(lines, output, LINE_SEP)) {
-        SYSERROR("%s", "unable to tokenize installed package list");
+        SYSERROR("unable to tokenize installed package list");
         guard_free(output);
         strlist_free(&lines);
         status = -1;
@@ -181,7 +181,7 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
     for (size_t i = 0; i < strlist_count(lines); i++) {
         char *line = strlist_item(lines, i);
         if (!line) {
-            SYSERROR("%s", "line is NULL");
+            SYSERROR("line is NULL");
             status = -1;
             goto cleanup;
         }
@@ -193,20 +193,20 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
 
         struct StrList *tokens = strlist_init();
         if (!tokens) {
-            SYSERROR("%s", "unable to allocate memory for tokenized installed package list");
+            SYSERROR("unable to allocate memory for tokenized installed package list");
             status = -1;
             goto cleanup;
         }
 
         if (strlist_append_tokenize(tokens, line, " ")) {
-            SYSERROR("%s", "unable to tokenize installed package list");
+            SYSERROR("unable to tokenize installed package list");
             status = -1;
             goto cleanup;
         }
 
         const char *installed_version = strlist_item(tokens, 1);
         if (!installed_version) {
-            SYSERROR("%s", "not enough data in line (name and version not found)");
+            SYSERROR("not enough data in line (name and version not found)");
             guard_strlist_free(&tokens);
             status = -1;
             goto cleanup;
@@ -215,7 +215,7 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
         if (strstr(line, name)) {
             spec_installed = strdup(installed_version);
             if (!spec_installed) {
-                SYSERROR("%s", "unable to allocated memory for installed package version");
+                SYSERROR("unable to allocated memory for installed package version");
                 guard_strlist_free(&tokens);
                 status = -1;
                 goto cleanup;
@@ -242,7 +242,7 @@ int delivery_conda_enforce_package_version(struct Delivery *ctx, const char *env
 
             spec_request = strdup(spec_tmp);
             if (!spec_request) {
-                SYSERROR("%s", "unable to allocate memory for conda package spec request");
+                SYSERROR("unable to allocate memory for conda package spec request");
                 status = -1;
                 goto cleanup;
             }
@@ -321,7 +321,7 @@ int delivery_purge_packages(struct Delivery *ctx, const char *env_name, int use_
         char *package = strlist_item(list, i);
         char *command = NULL;
         if (asprintf(&command, "%s '%s'", subcommand, package) < 0) {
-            SYSERROR("%s", "Unable to allocate bytes for removal command");
+            SYSERROR("Unable to allocate bytes for removal command");
             status = -1;
             break;
         }
@@ -389,7 +389,7 @@ int delivery_install_packages(struct Delivery *ctx, char *conda_install_dir, cha
     size_t args_alloc_len = STASIS_BUFSIZ;
     char *args = calloc(args_alloc_len + 1, sizeof(*args));
     if (!args) {
-        SYSERROR("%s", "Unable to allocate bytes for command arguments");
+        SYSERROR("Unable to allocate bytes for command arguments");
         return -1;
     }
 
@@ -407,7 +407,7 @@ int delivery_install_packages(struct Delivery *ctx, char *conda_install_dir, cha
                     if (!strcmp(info->version, "HEAD") || is_git_sha(info->version)) {
                         struct StrList *tag_data = strlist_init();
                         if (!tag_data) {
-                            SYSERROR("%s", "Unable to allocate memory for tag data\n");
+                            SYSERROR("Unable to allocate memory for tag data");
                             guard_free(args);
                             return -1;
                         }
@@ -432,7 +432,7 @@ int delivery_install_packages(struct Delivery *ctx, char *conda_install_dir, cha
                                                          NULL}, WHEEL_MATCH_ANY);
                         if (!whl && errno) {
                             // error
-                            SYSERROR("Unable to read Python wheel info: %s\n", strerror(errno));
+                            SYSERROR("Unable to read Python wheel info: %s", strerror(errno));
                             exit(1);
                         } else if (!whl) {
                             // not found
@@ -505,7 +505,7 @@ int delivery_install_packages(struct Delivery *ctx, char *conda_install_dir, cha
         }
         char *command = NULL;
         if (asprintf(&command, "%s %s", command_base, args) < 0) {
-            SYSERROR("%s", "Unable to allocate bytes for command\n");
+            SYSERROR("Unable to allocate bytes for command");
             guard_free(args);
             return -1;
         }

--- a/src/lib/delivery/delivery_install.c
+++ b/src/lib/delivery/delivery_install.c
@@ -1,4 +1,7 @@
 #include "delivery.h"
+#include "conda.h"
+#include "wheelinfo.h"
+#include "version_compare.h"
 
 static struct Test *requirement_from_test(struct Delivery *ctx, const char *name) {
     struct Test *result = NULL;

--- a/src/lib/delivery/delivery_populate.c
+++ b/src/lib/delivery/delivery_populate.c
@@ -55,7 +55,7 @@ int populate_info(struct Delivery *ctx) {
 int populate_delivery_cfg(struct Delivery *ctx, int render_mode) {
     struct INIFILE *cfg = ctx->_stasis_ini_fp.cfg;
     if (!cfg) {
-        SYSDEBUG("%s", "cfg is NULL");
+        SYSDEBUG("cfg is NULL");
         return -1;
     }
     int err = 0;
@@ -92,7 +92,7 @@ int populate_delivery_cfg(struct Delivery *ctx, int render_mode) {
             msg(STASIS_MSG_WARN, "wheel_builder is undefined. Falling back to system toolchain: 'build'.\n");
             globals.wheel_builder = strdup("build");
             if (!globals.wheel_builder) {
-                SYSERROR("%s", "unable to allocate memory for default wheel_builder value");
+                SYSERROR("unable to allocate memory for default wheel_builder value");
                 return -1;
             }
         }
@@ -104,14 +104,14 @@ int populate_delivery_cfg(struct Delivery *ctx, int render_mode) {
     }
 
     if (err && globals.wheel_builder && strcmp(globals.wheel_builder, "manylinux") == 0) {
-        SYSERROR("%s", "default:wheel_builder is set to 'manylinux', however default:wheel_builder_manylinux_image is not configured");
+        SYSERROR("default:wheel_builder is set to 'manylinux', however default:wheel_builder_manylinux_image is not configured");
         return -1;
     }
 
     if (strcmp(globals.wheel_builder, "manylinux") == 0) {
         char *manifest_inspect_cmd = NULL;
         if (asprintf(&manifest_inspect_cmd, "manifest inspect '%s'", globals.wheel_builder_manylinux_image) < 0) {
-            SYSERROR("%s", "unable to allocate memory for docker command");
+            SYSERROR("unable to allocate memory for docker command");
             guard_free(manifest_inspect_cmd);
             return -1;
         }
@@ -285,7 +285,7 @@ int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
             union INIVal val;
             struct Test *test = test_init();
             if (!test) {
-                SYSERROR("%s", "unable to allocate memory for test structure");
+                SYSERROR("unable to allocate memory for test structure");
                 return -1;
             }
 
@@ -383,7 +383,7 @@ int populate_mission_ini(struct Delivery **ctx, int render_mode) {
                 globals.sysconfdir, "mission", (*ctx)->meta.mission, (*ctx)->meta.mission);
     }
 
-    SYSDEBUG("Reading mission configuration: %s\n", missionfile);
+    SYSDEBUG("Reading mission configuration: %s", missionfile);
     (*ctx)->_stasis_ini_fp.mission = ini_open(missionfile);
     struct INIFILE *ini = (*ctx)->_stasis_ini_fp.mission;
     if (!ini) {
@@ -404,7 +404,7 @@ int populate_mission_ini(struct Delivery **ctx, int render_mode) {
 
 void validate_delivery_ini(struct INIFILE *ini) {
     if (!ini) {
-        SYSERROR("%s", "INIFILE is NULL!");
+        SYSERROR("INIFILE is NULL!");
         exit(1);
     }
     if (ini_section_search(&ini, INI_SEARCH_EXACT, "meta")) {
@@ -414,7 +414,7 @@ void validate_delivery_ini(struct INIFILE *ini) {
         ini_has_key_required(ini, "meta", "mission");
         ini_has_key_required(ini, "meta", "python");
     } else {
-        SYSERROR("%s", "[meta] configuration section is required");
+        SYSERROR("[meta] configuration section is required");
         exit(1);
     }
 
@@ -424,7 +424,7 @@ void validate_delivery_ini(struct INIFILE *ini) {
         ini_has_key_required(ini, "conda", "installer_platform");
         ini_has_key_required(ini, "conda", "installer_arch");
     } else {
-        SYSERROR("%s", "[conda] configuration section is required");
+        SYSERROR("[conda] configuration section is required");
         exit(1);
     }
 

--- a/src/lib/delivery/delivery_postprocess.c
+++ b/src/lib/delivery/delivery_postprocess.c
@@ -1,4 +1,6 @@
 #include "delivery.h"
+#include "log.h"
+#include "conda.h"
 
 
 const char *release_header = "# delivery_name: %s\n"

--- a/src/lib/delivery/delivery_postprocess.c
+++ b/src/lib/delivery/delivery_postprocess.c
@@ -74,7 +74,7 @@ void delivery_rewrite_spec(struct Delivery *ctx, char *filename, unsigned stage)
     FILE *tp = NULL;
 
     if (stage == DELIVERY_REWRITE_SPEC_STAGE_1) {
-        SYSDEBUG("%s", "Entering stage 1");
+        SYSDEBUG("Entering stage 1");
         header = delivery_get_release_header(ctx);
         SYSDEBUG("Release header:\n%s", header);
         if (!header) {
@@ -143,38 +143,38 @@ void delivery_rewrite_spec(struct Delivery *ctx, char *filename, unsigned stage)
         remove(tempfile);
         guard_free(tempfile);
     } else if (globals.enable_rewrite_spec_stage_2 && stage == DELIVERY_REWRITE_SPEC_STAGE_2) {
-        SYSDEBUG("%s", "Entering stage 2");
+        SYSDEBUG("Entering stage 2");
         char output[PATH_MAX] = {0};
         // Replace "local" channel with the staging URL
         if (ctx->storage.conda_staging_url) {
-            SYSDEBUG("%s", "Will replace conda channel with staging area url");
+            SYSDEBUG("Will replace conda channel with staging area url");
             file_replace_text(filename, "@CONDA_CHANNEL@", ctx->storage.conda_staging_url, 0);
         } else if (globals.jfrog.repo) {
-            SYSDEBUG("%s", "Will replace conda channel with artifactory repo packages/conda url");
+            SYSDEBUG("Will replace conda channel with artifactory repo packages/conda url");
             snprintf(output, sizeof(output), "%s/%s/%s/%s/packages/conda", globals.jfrog.url, globals.jfrog.repo, ctx->meta.mission, ctx->info.build_name);
             file_replace_text(filename, "@CONDA_CHANNEL@", output, 0);
         } else {
-            SYSDEBUG("%s", "Will replace conda channel with local conda artifact directory");
+            SYSDEBUG("Will replace conda channel with local conda artifact directory");
             msg(STASIS_MSG_WARN, "conda_staging_dir is not configured. Using fallback: '%s'\n", ctx->storage.conda_artifact_dir);
             file_replace_text(filename, "@CONDA_CHANNEL@", ctx->storage.conda_artifact_dir, 0);
         }
 
         if (ctx->storage.wheel_staging_url) {
-            SYSDEBUG("%s", "Will replace pip arguments with wheel staging url");
+            SYSDEBUG("Will replace pip arguments with wheel staging url");
             snprintf(output, sizeof(output), "--extra-index-url %s/%s/%s/packages/wheels", ctx->storage.wheel_staging_url, ctx->meta.mission, ctx->info.build_name);
             file_replace_text(filename, "@PIP_ARGUMENTS@", ctx->storage.wheel_staging_url, 0);
         } else if (globals.enable_artifactory && globals.jfrog.url && globals.jfrog.repo) {
-            SYSDEBUG("%s", "Will replace pip arguments with artifactory repo packages/wheel url");
+            SYSDEBUG("Will replace pip arguments with artifactory repo packages/wheel url");
             snprintf(output, sizeof(output), "--extra-index-url %s/%s/%s/%s/packages/wheels", globals.jfrog.url, globals.jfrog.repo, ctx->meta.mission, ctx->info.build_name);
             file_replace_text(filename, "@PIP_ARGUMENTS@", output, 0);
         } else {
-            SYSDEBUG("%s", "Will replace pip arguments with local wheel artifact directory");
+            SYSDEBUG("Will replace pip arguments with local wheel artifact directory");
             msg(STASIS_MSG_WARN, "wheel_staging_dir is not configured. Using fallback: '%s'\n", ctx->storage.wheel_artifact_dir);
             snprintf(output, sizeof(output), "--extra-index-url file://%s", ctx->storage.wheel_artifact_dir);
             file_replace_text(filename, "@PIP_ARGUMENTS@", output, 0);
         }
     }
-    SYSDEBUG("%s", "Rewriting finished");
+    SYSDEBUG("Rewriting finished");
 }
 
 int delivery_copy_conda_artifacts(struct Delivery *ctx) {
@@ -284,6 +284,6 @@ int delivery_index_wheel_artifacts(struct Delivery *ctx) {
     }
     closedir(dp);
     fclose(top_fp);
-    SYSDEBUG("%s", "Wheel indexing complete");
+    SYSDEBUG("Wheel indexing complete");
     return 0;
 }

--- a/src/lib/delivery/delivery_test.c
+++ b/src/lib/delivery/delivery_test.c
@@ -18,9 +18,7 @@ struct Tests *tests_init(const size_t num_tests) {
 
 int tests_add(struct Tests *tests, struct Test *x) {
     if (tests->num_used >= tests->num_alloc) {
-#ifdef DEBUG
         const size_t old_alloc = tests->num_alloc;
-#endif
         struct Test **tmp = realloc(tests->test, tests->num_alloc++ * sizeof(**tests->test));
         SYSDEBUG("Increasing size of test array: %zu -> %zu", old_alloc, tests->num_alloc);
         if (!tmp) {

--- a/src/lib/delivery/delivery_test.c
+++ b/src/lib/delivery/delivery_test.c
@@ -319,7 +319,7 @@ void delivery_tests_run(struct Delivery *ctx) {
                     guard_free(cmd);
                     popd();
                 } else {
-                    SYSERROR("Failed to change directory: %s\n", destdir);
+                    SYSERROR("Failed to change directory: %s", destdir);
                     exit(1);
                 }
             }

--- a/src/lib/delivery/include/delivery.h
+++ b/src/lib/delivery/include/delivery.h
@@ -5,23 +5,11 @@
 
 #include <string.h>
 #include <stdbool.h>
-#include <unistd.h>
-#include <sys/utsname.h>
-#include <fnmatch.h>
-#include <sys/statvfs.h>
 #include "artifactory.h"
-#include "conda.h"
-#include "copy.h"
-#include "core.h"
 #include "docker.h"
 #include "environment.h"
 #include "ini.h"
 #include "multiprocessing.h"
-#include "recipe.h"
-#include "wheel.h"
-#include "wheelinfo.h"
-#include "environment.h"
-#include "version_compare.h"
 
 #define DELIVERY_PLATFORM_MAX 4
 #define DELIVERY_PLATFORM_MAXLEN 65

--- a/tests/include/testing.h
+++ b/tests/include/testing.h
@@ -214,6 +214,7 @@ inline void stasis_testing_teardown_workspace() {
             SYSERROR("%s", "Unable to determine current working directory"); \
             exit(1); \
         } \
+        LOG_LEVEL = LOG_LEVEL_DEBUG; \
         atexit(stasis_testing_record_result_summary); \
         atexit(stasis_testing_teardown_workspace); \
         stasis_testing_setup_workspace(); \

--- a/tests/test_artifactory.c
+++ b/tests/test_artifactory.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
     // Skip this suite if we're not configured to use it
     if (jfrt_auth_init(&gauth)) {
-        SYSERROR("%s", "Not configured to test Artifactory. Skipping.");
+        SYSERROR("Not configured to test Artifactory. Skipping.");
         guard_free(basedir);
         return STASIS_TEST_SUITE_SKIP;
     }

--- a/tests/test_wheel.c
+++ b/tests/test_wheel.c
@@ -1,3 +1,4 @@
+#include "conda.h"
 #include "delivery.h"
 #include "testing.h"
 #include "str.h"


### PR DESCRIPTION
- `SYSERROR` and `SYSDEBUG` now use new `log_print_*` functions.
- `SYSINFO` and `SYSWARN` macros have been added.
- The `DEBUG_MESSAGES` cmake option will be renamed at some point. Debug messages can be activated with multiple verbose arguments (i.e. `-vv`)
- All calls to `SYSERROR` and `SYSDEBUG` have been consolidated to use variadic arguments correctly. `SYSERROR("%s", "string here")` is no longer necessary. `SYSERROR("string here")` works now. 