### PR TITLE
Micromamba improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,14 @@ stasis mydelivery.ini
 
 ## Indexer Command Line Options
 
-| Long Option  | Short Option | Purpose                                 |
-|:-------------|:------------:|:----------------------------------------|
-| --help       |      -h      | Display this usage statement            |
-| --destdir    |      -d      | Destination directory                   |
-| --verbose    |      -v      | Increase output verbosity               |
-| --unbuffered |      -U      | Disable line buffering                  |
-| --web        |      -w      | Generate HTML indexes (requires pandoc) |
+| Long Option               | Short Option | Purpose                                 |
+|:--------------------------|:------------:|:----------------------------------------|
+| --help                    |      -h      | Display this usage statement            |
+| --destdir                 |      -d      | Destination directory                   |
+| --verbose                 |      -v      | Increase output verbosity               |
+| --unbuffered              |      -U      | Disable line buffering                  |
+| --web                     |      -w      | Generate HTML indexes (requires pandoc) |
+| --micromamba-download-url |     n/a      | Set micromamba download URL             |
 
 ## Environment variables
 

--- a/src/cli/stasis_indexer/args.c
+++ b/src/cli/stasis_indexer/args.c
@@ -7,6 +7,7 @@ struct option long_options[] = {
     {"verbose", no_argument, 0, 'v'},
     {"unbuffered", no_argument, 0, 'U'},
     {"web", no_argument, 0, 'w'},
+    {"micromamba-download-url", required_argument, 0, OPT_MICROMAMBA_DOWNLOAD_URL},
     {0, 0, 0, 0},
 };
 
@@ -16,6 +17,7 @@ const char *long_options_help[] = {
     "Increase output verbosity",
     "Disable line buffering",
     "Generate HTML indexes (requires pandoc)",
+    "Set micromamba download URL",
     NULL,
 };
 

--- a/src/cli/stasis_indexer/args.c
+++ b/src/cli/stasis_indexer/args.c
@@ -28,17 +28,23 @@ void usage(char *name) {
         SYSERROR("Unable to allocate memory for options array");
         exit(1);
     }
-    for (int i = 0; i < maxopts; i++) {
-        opts[i] = (char) long_options[i].val;
+    for (int i = 0, n = 0; i < maxopts; i++) {
+        if (isalnum(long_options[i].val)) {
+            opts[n] = (char) long_options[i].val;
+            n++;
+        }
     }
     printf("usage: %s [-%s] {{STASIS_ROOT} ...}\n", name, opts);
     guard_free(opts);
 
     for (int i = 0; i < maxopts - 1; i++) {
         char line[255] = {0};
-        snprintf(line, sizeof(line), "  --%s  -%c  %-20s", long_options[i].name, long_options[i].val, long_options_help[i]);
+        snprintf(line, sizeof(line), "  --%s  %s%c  %s",
+            long_options[i].name,
+            isalnum(long_options[i].val) ? "-" : "",
+            isalnum(long_options[i].val) ? long_options[i].val : ' ',
+            long_options_help[i]);
         puts(line);
     }
 
 }
-

--- a/src/cli/stasis_indexer/args.c
+++ b/src/cli/stasis_indexer/args.c
@@ -31,7 +31,7 @@ void usage(char *name) {
     for (int i = 0; i < maxopts; i++) {
         opts[i] = (char) long_options[i].val;
     }
-    printf("usage: %s [-%s] {{STASIS_ROOT}...}\n", name, opts);
+    printf("usage: %s [-%s] {{STASIS_ROOT} ...}\n", name, opts);
     guard_free(opts);
 
     for (int i = 0; i < maxopts - 1; i++) {

--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -172,6 +172,11 @@ int micromamba_configure(const struct Delivery *ctx, struct MicromambaInfo *m) {
     setenv("PATH", pathvar, 1);
     guard_free(pathvar);
 
+    if (micromamba_install(m)) {
+        SYSERROR("Micromamba installation failed");
+        return -1;
+    }
+
     status += micromamba(m, "config prepend --env channels conda-forge");
     if (!globals.verbose) {
         status += micromamba(m, "config set --env quiet true");

--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -157,6 +157,7 @@ int micromamba_configure(const struct Delivery *ctx, struct MicromambaInfo *m) {
     m->conda_prefix = globals.conda_install_prefix;
     m->micromamba_prefix = micromamba_prefix;
     m->download_dir = ctx->storage.tmpdir;
+    m->download_url = globals.micromamba_download_url;
 
     const size_t pathvar_len = strlen(getenv("PATH")) + strlen(m->micromamba_prefix) + strlen(m->conda_prefix) + 3 + 4 + 1;
     // ^^^^^^^^^^^^^^^^^^

--- a/src/cli/stasis_indexer/include/args.h
+++ b/src/cli/stasis_indexer/include/args.h
@@ -3,6 +3,8 @@
 
 #include <getopt.h>
 
+#define OPT_MICROMAMBA_DOWNLOAD_URL 1000
+
 extern struct option long_options[];
 void usage(char *name);
 

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -197,6 +197,13 @@ int main(const int argc, char *argv[]) {
             case 'w':
                 do_html = 1;
                 break;
+            case OPT_MICROMAMBA_DOWNLOAD_URL:
+                globals.micromamba_download_url = strdup(optarg);
+                if (!globals.micromamba_download_url) {
+                    SYSERROR("unable to allocate memory for micromamba_download_url");
+                    exit(1);
+                }
+                break;
             case '?':
             default:
                 exit(1);
@@ -324,6 +331,13 @@ int main(const int argc, char *argv[]) {
     }
     else {
         SYSWARN("Unable to open stasis configuration file: %s", cfg_path);
+    }
+
+    if (globals.micromamba_download_url && isempty(globals.micromamba_download_url)) {
+        // safeguard against supplying a zero-length URL
+        // this covers the case where the user supplied it as an argument and/or in the config file
+        SYSERROR("micromamba download URL cannot be empty");
+        exit(1);
     }
 
     indexer_init_dirs(&ctx, workdir);

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -309,6 +309,23 @@ int main(const int argc, char *argv[]) {
     printf(BANNER, version, AUTHOR);
     guard_free(version);
 
+    char *cfg_path = NULL;
+    if (asprintf(&cfg_path, "%s/stasis.ini", globals.sysconfdir) < 0) {
+        SYSERROR("Unable to allocate memory for cfg path");
+        exit(1);
+    }
+    ctx._stasis_ini_fp.cfg_path = cfg_path;
+    ctx._stasis_ini_fp.cfg = ini_open(ctx._stasis_ini_fp.cfg_path);
+    if (ctx._stasis_ini_fp.cfg) {
+        if (populate_delivery_cfg(&ctx, INI_READ_RENDER)) {
+            SYSERROR("Unable to apply stasis configuration");
+            exit(1);
+        }
+    }
+    else {
+        SYSWARN("Unable to open stasis configuration file: %s", cfg_path);
+    }
+
     indexer_init_dirs(&ctx, workdir);
 
     msg(STASIS_MSG_L1, "%s delivery root %s\n",

--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -5,7 +5,11 @@
 #include "conda.h"
 #include "version_compare.h"
 
-int micromamba(const struct MicromambaInfo *info, char *command, ...) {
+int micromamba_install(const struct MicromambaInfo *info) {
+    if (access(info->micromamba_prefix, F_OK) == 0) {
+        SYSINFO("micromamba already installed: %s", info->micromamba_prefix);
+        return 0;
+    }
     struct utsname sys;
     uname(&sys);
 
@@ -28,21 +32,52 @@ int micromamba(const struct MicromambaInfo *info, char *command, ...) {
         return -1;
     }
 
+    // If we ever want an exact version instead of "latest", we need to use this format instead:
+    // https://github.com/mamba-org/micromamba-releases/releases/download/${version}/micromamba-${arch}
+
+    // Micromamba hosts binaries on github and on their own website. Prefer github.
+    const char *url_fmts[] = {
+        info->download_url,
+        "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-%s-%s",
+        "https://micro.mamba.pm/api/micromamba/%s-%s/latest",
+    };
+    const size_t url_fmts_max = sizeof(url_fmts) / sizeof(url_fmts[0]);
+
     char url[PATH_MAX] = {0};
-    snprintf(url, sizeof(url), "https://micro.mamba.pm/api/micromamba/%s-%s/latest", sys.sysname, sys.machine);
-
-    const char installer_name[] = "mm_latest";
     char installer_path[PATH_MAX] = {0};
-    snprintf(installer_path, sizeof(installer_path), "%s/%s", info->download_dir, installer_name);
+    const char *installer_name = "mm_latest";
 
-    if (access(installer_path, F_OK)) {
-        char *errmsg = NULL;
-        const long http_code = download(url, installer_path, &errmsg);
-        if (HTTP_ERROR(http_code)) {
-            SYSERROR("download failed: %ld: %s", http_code, errmsg);
-            guard_free(errmsg);
-            return -1;
+    size_t fail_count = 0;
+    for (size_t url_i = 0; url_i < url_fmts_max; url_i++) {
+        if (url_i == 0 && info->download_url) {
+            // If the caller supplies a download_url, use it
+            snprintf(url, sizeof(url), "%s", info->download_url);
+        } else if (url_i == 0 && isempty(info->download_url)) {
+            // No download_url has been defined, or is an empty string
+            continue;
+        } else {
+            snprintf(url, sizeof(url), url_fmts[url_i], sys.sysname, sys.machine);
         }
+
+        snprintf(installer_path, sizeof(installer_path), "%s/%s", info->download_dir, installer_name);
+
+        if (access(installer_path, F_OK)) {
+            char *errmsg = NULL;
+            const long http_code = download(url, installer_path, &errmsg);
+            if (HTTP_ERROR(http_code)) {
+                SYSERROR("download failed: %ld: %s", http_code, errmsg);
+                guard_free(errmsg);
+                remove(installer_path);
+                fail_count++;
+                continue;
+            }
+            break;
+        }
+    }
+
+    if (fail_count >= url_fmts_max) {
+        SYSERROR("all download attempts failed");
+        return -1;
     }
 
     char mmbin[PATH_MAX];
@@ -58,6 +93,16 @@ int micromamba(const struct MicromambaInfo *info, char *command, ...) {
         if (untarcmd_status) {
             return -1;
         }
+    }
+    return 0;
+}
+
+int micromamba(const struct MicromambaInfo *info, char *command, ...) {
+    char mmbin[PATH_MAX] = {0};
+    snprintf(mmbin, sizeof(mmbin), "%s/micromamba", info->micromamba_prefix);
+    if (access(mmbin, F_OK) < 0) {
+        SYSERROR("Unable to run micromamba. Not installed?");
+        return -1;
     }
 
     char cmd[STASIS_BUFSIZ] = {0};

--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -36,9 +36,10 @@ int micromamba_install(const struct MicromambaInfo *info) {
     // https://github.com/mamba-org/micromamba-releases/releases/download/${version}/micromamba-${arch}
 
     // Micromamba hosts binaries on github and on their own website. Prefer github.
+    // The "latest" binary from micromamba's site is compressed with bzip2 (06/2026)
     const char *url_fmts[] = {
         info->download_url,
-        "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-%s-%s",
+        "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-%s-%s.tar.bz2",
         "https://micro.mamba.pm/api/micromamba/%s-%s/latest",
     };
     const size_t url_fmts_max = sizeof(url_fmts) / sizeof(url_fmts[0]);
@@ -84,14 +85,26 @@ int micromamba_install(const struct MicromambaInfo *info) {
     snprintf(mmbin, sizeof(mmbin), "%s/micromamba", info->micromamba_prefix);
 
     if (access(mmbin, F_OK)) {
-        char untarcmd[PATH_MAX * 2];
         mkdirs(info->micromamba_prefix, 0755);
-        snprintf(untarcmd, sizeof(untarcmd),
-            "tar -xvf %s -C %s --strip-components=1 bin/micromamba 1>/dev/null",
-            installer_path, info->micromamba_prefix);
-        int untarcmd_status = system(untarcmd);
-        if (untarcmd_status) {
-            return -1;
+
+        if (is_file_compressed(installer_path)) {
+            char untarcmd[PATH_MAX * 2] = {0};
+            snprintf(untarcmd, sizeof(untarcmd),
+                "tar -xvf %s -C %s --strip-components=1 bin/micromamba 1>/dev/null",
+                installer_path, info->micromamba_prefix);
+            int untarcmd_status = system(untarcmd);
+            if (untarcmd_status) {
+                return -1;
+            }
+        } else {
+            if (copy2(installer_path, mmbin, CT_PERM)) {
+                SYSERROR("unable to copy %s to %s", installer_path, mmbin);
+                return -1;
+            }
+            if (chmod(mmbin, 0755)) {
+                SYSERROR("unable to set permissions: %s (%s)", mmbin, strerror(errno));
+                return -1;
+            }
         }
     }
     return 0;

--- a/src/lib/core/globals.c
+++ b/src/lib/core/globals.c
@@ -29,6 +29,7 @@ struct STASIS_GLOBAL globals = {
         .verbose = false, ///< Toggle verbose mode
         .continue_on_error = false, ///< Do not stop program on error
         .always_update_base_environment = false, ///< Run "conda update --all" after installing Conda
+        .micromamba_download_url = NULL,
         .conda_fresh_start = true, ///< Remove/reinstall Conda at startup
         .conda_install_prefix = NULL, ///< Path to install Conda
         .conda_packages = NULL, ///< Conda packages to install

--- a/src/lib/core/include/conda.h
+++ b/src/lib/core/include/conda.h
@@ -30,7 +30,16 @@ struct MicromambaInfo {
     char *micromamba_prefix;    //!< Path to write micromamba binary
     char *conda_prefix;         //!< Path to install conda base tree
     char *download_dir;         //!< Path to store micromamba installer
+    char *download_url;         //!< Raw URL to a remotely hosted micromamba-platform-arch file
 };
+
+/**
+ * Download and install Micromamba
+ *
+ * @param info MicromambaInfo data structure (must be populated before use)
+ * @return 0 on successful installation
+ */
+int micromamba_install(const struct MicromambaInfo *info);
 
 /**
  * Execute micromamba

--- a/src/lib/core/include/core.h
+++ b/src/lib/core/include/core.h
@@ -35,6 +35,7 @@ struct STASIS_GLOBAL {
     bool verbose; //!< Enable verbose output
     bool always_update_base_environment; //!< Update base environment immediately after activation
     bool continue_on_error; //!< Do not stop on test failures
+    char *micromamba_download_url; //!< Override download URL for micromamba
     bool conda_fresh_start; //!< Always install a new copy of Conda
     bool enable_docker; //!< Enable docker image builds
     bool enable_artifactory; //!< Enable artifactory uploads

--- a/src/lib/core/include/utils.h
+++ b/src/lib/core/include/utils.h
@@ -492,4 +492,22 @@ int get_random_bytes(char *result, size_t maxlen);
 int non_format_len(const char *s);
 
 char *center_text(const char *s, size_t maxwidth);
+
+/**
+ * Check magic bytes against known compression formats
+ *
+ * ```c
+ * const char *filename = "/path/to/file.zip";
+ * if (is_file_compressed(filename)) {
+ *     // file is compressed
+ * } else {
+ *     // file is not compressed
+ * }
+ * ```
+ *
+ * @param filename path to maybe-compressed file
+ * @return 0 if not compressed
+ * @return 1 if compressed
+ */
+int is_file_compressed(const char *filename);
 #endif //STASIS_UTILS_H

--- a/src/lib/core/utils.c
+++ b/src/lib/core/utils.c
@@ -1273,3 +1273,49 @@ char *center_text(const char *s, const size_t maxwidth) {
     return result;
 }
 
+int is_file_compressed(const char *filename) {
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        SYSERROR("Unable to open for reading: %s", filename);
+        return -1;
+    }
+
+    // Container for magic bytes
+    struct Magic {
+        const unsigned char *byte;
+        const size_t size;
+    };
+
+    // Array of magic bytes for different compression types
+    const struct Magic magic[] = {
+        {(unsigned char *) "BZh", 3},                       // bzip2
+        {(unsigned char *) "\x1f\x8b", 2},                  // gzip
+        {(unsigned char *) "\xfd\x37\x7a\x58\x5a\x00", 6},  // xz
+        {(unsigned char *) "PK\03\04", 3},                  // zip
+        {(unsigned char *) "PK\05\06", 3},                  // zip (empty)
+        {(unsigned char *) "PK\07\08", 3},                  // zip (spanned)
+        {(unsigned char *) "\xfd\x2f\xb5\x28", 4}           // zstd
+    };
+    unsigned char buf[8] = {0}; // unsigned long
+    size_t bytes_read = 0;
+    bytes_read = fread(buf, 1, sizeof(buf), fp);
+    if (bytes_read < sizeof(buf)) {
+        SYSWARN("consumed fewer than %zu bytes (%zu) from %s", sizeof(buf), bytes_read, filename);
+        fclose(fp);
+        // well, the file isn't compressed.
+        return 0;
+    }
+    fclose(fp);
+
+    // Compare known magic bytes to consumed data
+    for (size_t i = 0; i < sizeof(magic) / sizeof(magic[0]); i++) {
+        if (memcmp(buf, magic[i].byte, magic[i].size) == 0) {
+            // match
+            return 1;
+        }
+    }
+
+    // no match
+    return 0;
+}
+

--- a/src/lib/delivery/delivery_populate.c
+++ b/src/lib/delivery/delivery_populate.c
@@ -99,6 +99,11 @@ int populate_delivery_cfg(struct Delivery *ctx, int render_mode) {
     }
 
     err = 0;
+    if (!globals.micromamba_download_url) {
+        globals.micromamba_download_url = ini_getval_str(cfg, "indexer", "micromamba_download_url", render_mode, &err);
+    }
+
+    err = 0;
     if (!globals.wheel_builder_manylinux_image) {
         globals.wheel_builder_manylinux_image = ini_getval_str(cfg, "default", "wheel_builder_manylinux_image", render_mode, &err);
     }

--- a/stasis.ini
+++ b/stasis.ini
@@ -35,6 +35,15 @@ wheel_builder = manylinux
 ; When wheel_builder is set to "manylinux", use the following image
 wheel_builder_manylinux_image = quay.io/pypa/manylinux2014
 
+
+;[indexer]
+; (string) Micromamba download URL
+; DEFAULT: GitHub or Micromamba's primary website URLs are used
+; NOTE:
+;   - The platform and architecture combination must be handled by the user
+;micromamba_download_url = https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-PLAT-ARCH
+
+
 [jfrog_cli_download]
 url = https://releases.jfrog.io/artifactory
 product = jfrog-cli

--- a/tests/test_conda.c
+++ b/tests/test_conda.c
@@ -26,6 +26,7 @@ void test_micromamba() {
 
     for (size_t i = 0; i < sizeof(tc) / sizeof(*tc); i++) {
         struct testcase *item = &tc[i];
+        STASIS_ASSERT(micromamba_install(&item->mminfo) == 0, "micromamba installation failed");
         int result = micromamba(&item->mminfo, (char *) item->cmd);
         if (result > 0) {
             result = result >> 8;


### PR DESCRIPTION
`micromamba_install` now attempts to download `micromamba` from github releases first, and if that fails tries micromamba's website. The user can supply their own micromamba download url via the main `stasis.ini`, or a command line argument passed to the indexer.

```
[indexer]
micromamba_download_url = https://example.tld/micromamba-binary-image
```
or
```
stasis_indexer --micromamba-download-url=https://example.tld/micromamba-binary-image
```

Micromamba distributes compressed and uncompressed binaries, so `is_file_compressed()` was added to `utils.c` to make sure `micromamba_install` takes the correct action based on whatever is fed to it. This function is significantly cheaper than `libmagic` but nowhere near comprehensive in any way. If they switch to a compression program unknown to stasis, the installation will fail. At the moment we can detect bzip2, gzip, zip, xz, and zstd.