### PR TITLE
Bugfix 0x1003

### DIFF
--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -310,33 +310,6 @@ int pkg_index_provides(int mode, const char *index, const char *spec, const char
         }
     }
 
-    if (status != 0) {
-        SYSERROR("Command exited non-zero (%d)", status);
-        for (size_t i = 0; i < sizeof(logfile) / sizeof(logfile[0]); i++) {
-            const char *stream_name = i == 0 ? "stdout" : "stderr";
-            if (!logfile_st[i].st_size) {
-                continue;
-            }
-            SYSDEBUG("(%s): %s", stream_name, logfile[i]);
-            FILE *fp = fdopen(logfile_fd[i], "r");
-            if (!fp) {
-                remove(logfile[i]);
-                return -1;
-            }
-
-            fflush(stdout);
-            fflush(stderr);
-
-            char line[STASIS_BUFSIZ] = {0};
-            while (fgets(line, sizeof(line) - 1, fp) != NULL) {
-                SYSINFO("(%s): %s", stream_name, strip(line));
-            }
-
-            fflush(stderr);
-            fclose(fp);
-        }
-    }
-
     if (WTERMSIG(proc.returncode)) {
         // This gets its own return value because if the external program
         // received a signal, even its status is zero, it's not reliable
@@ -371,6 +344,34 @@ int pkg_index_provides(int mode, const char *index, const char *spec, const char
         // Unfortunately this applies to botched version specs, too.
         final = PKG_NOT_FOUND;
     }
+
+    if (final != PKG_FOUND && final != PKG_NOT_FOUND) {
+        SYSERROR("Command exited non-zero (%d)", status);
+        for (size_t i = 0; i < sizeof(logfile) / sizeof(logfile[0]); i++) {
+            const char *stream_name = i == 0 ? "stdout" : "stderr";
+            if (!logfile_st[i].st_size) {
+                continue;
+            }
+            SYSDEBUG("(%s): %s", stream_name, logfile[i]);
+            FILE *fp = fdopen(logfile_fd[i], "r");
+            if (!fp) {
+                remove(logfile[i]);
+                return -1;
+            }
+
+            fflush(stdout);
+            fflush(stderr);
+
+            char line[STASIS_BUFSIZ] = {0};
+            while (fgets(line, sizeof(line) - 1, fp) != NULL) {
+                SYSINFO("(%s): %s", stream_name, strip(line));
+            }
+
+            fflush(stderr);
+            fclose(fp);
+        }
+    }
+
 
     // Remove log files
     for (size_t i = 0; i < sizeof(logfile) / sizeof(logfile[0]); i++) {

--- a/src/lib/core/multiprocessing.c
+++ b/src/lib/core/multiprocessing.c
@@ -89,7 +89,6 @@ int child(struct MultiProcessingPool *pool, struct MultiProcessingTask *task) {
 
     const int redirect = dup2(STDOUT_FILENO, STDERR_FILENO);
     if (redirect < 0) {
-        SYSERROR("%s", "Unable to redirect stderr to stdout");
         SYSERROR("Unable to redirect stderr to stdout");
         fclose(fp_log);
         semaphore_post(&pool->semaphore);

--- a/src/lib/delivery/delivery_build.c
+++ b/src/lib/delivery/delivery_build.c
@@ -466,6 +466,7 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                     if (mkdirs(outdir, 0755)) {
                         SYSERROR("failed to create output directory: %s", outdir);
                         guard_strlist_free(&result);
+                        popd();
                         return NULL;
                     }
                     if (use_builder_manylinux) {
@@ -474,18 +475,21 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                                     ctx->tests->test[i]->version);
                             guard_strlist_free(&result);
                             guard_free(cmd);
+                            popd();
                             return NULL;
                         }
                     } else if (use_builder_build || use_builder_cibuildwheel) {
                         if (use_builder_build) {
                             if (asprintf(&cmd, "-m build -w -o %s", outdir) < 0) {
                                 SYSERROR("Unable to allocate memory for build command");
+                                popd();
                                 return NULL;
                             }
                         } else if (use_builder_cibuildwheel) {
                             if (asprintf(&cmd, "-m cibuildwheel --output-dir %s --only cp%s-manylinux_%s",
                                 outdir, ctx->meta.python_compact, ctx->system.arch) < 0) {
                                 SYSERROR("Unable to allocate memory for cibuildwheel command");
+                                popd();
                                 return NULL;
                             }
                         }
@@ -495,10 +499,12 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                                     ctx->tests->test[i]->version);
                             guard_strlist_free(&result);
                             guard_free(cmd);
+                            popd();
                             return NULL;
                         }
                     } else {
                         SYSERROR("unknown wheel builder backend: %s", globals.wheel_builder);
+                        popd();
                         return NULL;
                     }
 

--- a/src/lib/delivery/delivery_test.c
+++ b/src/lib/delivery/delivery_test.c
@@ -160,7 +160,7 @@ void delivery_tests_run(struct Delivery *ctx) {
             if (!access(destdir, F_OK)) {
                 msg(STASIS_MSG_L3, "Purging repository %s\n", destdir);
                 if (rmtree(destdir)) {
-                    COE_CHECK_ABORT(1, "Unable to remove repository\n");
+                    COE_CHECK_ABORT(1, "Unable to remove repository");
                 }
             }
             msg(STASIS_MSG_L3, "Cloning repository %s\n", test->repository);
@@ -168,7 +168,7 @@ void delivery_tests_run(struct Delivery *ctx) {
                 test->repository_info_tag = strdup(git_describe(destdir));
                 test->repository_info_ref = strdup(git_rev_parse(destdir, "HEAD"));
             } else {
-                COE_CHECK_ABORT(1, "Unable to clone repository\n");
+                COE_CHECK_ABORT(1, "Unable to clone repository");
             }
 
             if (test->repository_remove_tags && strlist_count(test->repository_remove_tags)) {
@@ -176,7 +176,7 @@ void delivery_tests_run(struct Delivery *ctx) {
             }
 
             if (pushd(destdir)) {
-                COE_CHECK_ABORT(1, "Unable to enter repository directory\n");
+                COE_CHECK_ABORT(1, "Unable to enter repository directory");
             } else {
                 const int dep_status = check_python_package_dependencies(".");
                 if (dep_status) {

--- a/src/lib/delivery/delivery_test.c
+++ b/src/lib/delivery/delivery_test.c
@@ -217,6 +217,7 @@ void delivery_tests_run(struct Delivery *ctx) {
                 if (test->disable) {
                     msg(STASIS_MSG_L2, "Script execution disabled by configuration\n", test->name);
                     guard_free(cmd);
+                    popd();
                     continue;
                 }
 


### PR DESCRIPTION
This PR addresses:

- Error output from pip and conda while testing if a package exists on an index (or not) was too verbose. This reduces unnecessary output by only triggering the process output dump when a "real" error occurs.
- Test blocks with empty scripts, or errors, did not return (`popd`) from the top-level `pushd`
- Errant linefeeds in multiple `SYS*()` macro format strings were removed
- ~When `shell()`'s forked process is killed by a signal the return value should be non-zero~