### PR TITLE
Fix namespace wheel names

### DIFF
--- a/src/lib/core/include/utils.h
+++ b/src/lib/core/include/utils.h
@@ -519,4 +519,11 @@ char *center_text(const char *s, size_t maxwidth);
  * @return 1 if compressed
  */
 int is_file_compressed(const char *filename);
+
+/**
+ * Replace invalidated characters in package names with underscore
+ * @param name the package name
+ */
+size_t normalize_namespace_package_name(char *name);
+
 #endif //STASIS_UTILS_H

--- a/src/lib/core/utils.c
+++ b/src/lib/core/utils.c
@@ -1358,3 +1358,22 @@ int is_git_assumed_unchanged(char *filename) {
     guard_free(output);
     return 0;
 }
+
+size_t normalize_namespace_package_name(char *name) {
+    // "build" produces wheels with dashes and dots in the package name replaced by underscores
+    const char *invalid_chars = ".-";
+    size_t modified = 0;
+    const char *delim = strpbrk(name, "=");
+
+    do {
+        char *bad_char = strpbrk(name, invalid_chars);
+        if ((delim && bad_char) && bad_char > delim) {
+            break;
+        }
+        if (bad_char) {
+            *bad_char = '_';
+            modified++;
+        }
+    } while (strpbrk(name, invalid_chars));
+    return modified;
+}

--- a/src/lib/delivery/delivery.c
+++ b/src/lib/delivery/delivery.c
@@ -515,6 +515,8 @@ void delivery_defer_packages(struct Delivery *ctx, int type) {
         // When spec is present in name, set tests->version to the version detected in the name
         for (size_t x = 0; x < ctx->tests->num_used; x++) {
             struct Test *test = ctx->tests->test[x];
+            normalize_namespace_package_name(test->name);
+
             char nametmp[STASIS_NAME_MAX] = {0};
 
             safe_strncpy(nametmp, package_name, sizeof(nametmp));

--- a/src/lib/delivery/delivery_build.c
+++ b/src/lib/delivery/delivery_build.c
@@ -442,23 +442,37 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                 }
 
                 if (!pushd(srcdir)) {
-                    char dname[NAME_MAX];
-                    char outdir[PATH_MAX];
+                    char dname[NAME_MAX] = {0};
+                    char outdir[PATH_MAX] = {0};
+                    char linkname[PATH_MAX] = {0};
                     char *cmd = NULL;
-                    memset(dname, 0, sizeof(dname));
-                    memset(outdir, 0, sizeof(outdir));
 
                     delivery_autoresolve_vcs_urls(".");
 
                     safe_strncpy(dname, ctx->tests->test[i]->name, sizeof(dname));
                     tolower_s(dname);
                     snprintf(outdir, sizeof(outdir), "%s/%s", ctx->storage.wheel_artifact_dir, dname);
+
+                    // Despite generating packages using underscores in names, the directory name must use dashes
+                    // instead of underscores.
+                    safe_strncpy(linkname, dname, sizeof(linkname));
+                    replace_text(linkname, "_", "-", 0);
+
                     if (mkdirs(outdir, 0755)) {
                         SYSERROR("failed to create output directory: %s", outdir);
                         guard_strlist_free(&result);
                         popd();
                         return NULL;
                     }
+                    if (!pushd(ctx->storage.wheel_artifact_dir)) {
+                        symlink(dname, linkname);
+                        popd();
+                    } else {
+                        SYSERROR("unable to enter wheel storage directory: %s", ctx->storage.wheel_artifact_dir);
+                        guard_strlist_free(&result);
+                        return NULL;
+                    }
+
                     if (use_builder_manylinux) {
                         if (delivery_build_wheels_manylinux(ctx, outdir)) {
                             SYSERROR("failed to generate wheel package for %s-%s", ctx->tests->test[i]->name,

--- a/src/lib/delivery/delivery_populate.c
+++ b/src/lib/delivery/delivery_populate.c
@@ -285,12 +285,22 @@ int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
 
     ctx->conda.pip_packages = ini_getval_strlist(ini, "conda", "pip_packages", LINE_SEP, render_mode, &err);
     normalize_ini_list(&ini, &ctx->conda.pip_packages, "conda", "pip_packages", render_mode);
+    for (size_t i = 0; ctx->conda.pip_packages && i < strlist_count(ctx->conda.pip_packages); i++) {
+        char *item = strlist_item(ctx->conda.pip_packages, i);
+        normalize_namespace_package_name(item);
+    }
+
+    // Package specs should test for equality, or nothing at all
     if (check_package_spec_list(ctx->conda.pip_packages, "conda", "pip_packages")) {
         return -1;
     }
 
     ctx->conda.pip_packages_purge = ini_getval_strlist(ini, "conda", "pip_packages_purge", LINE_SEP, render_mode, &err);
     normalize_ini_list(&ini, &ctx->conda.pip_packages_purge, "conda", "pip_packages_purge", render_mode);
+    for (size_t i = 0; ctx->conda.pip_packages_purge && i < strlist_count(ctx->conda.pip_packages_purge); i++) {
+        char *item = strlist_item(ctx->conda.pip_packages_purge, i);
+        normalize_namespace_package_name(item);
+    }
 
     // Delivery metadata consumed
     if (populate_mission_ini(&ctx, render_mode)) {

--- a/tests/data/gbo.ini
+++ b/tests/data/gbo.ini
@@ -19,6 +19,7 @@ pip_packages =
     firewatch==0.0.4
     gwcs==0.22.1
     tweakwcs==0.9.0
+    stsci.imagestats==1.8.4
 
 
 [runtime]
@@ -44,6 +45,15 @@ script =
         --basetemp="{{ func:basetemp_dir() }}" \
         --junitxml="{{ func:junitxml_file() }}"
 
+[test:stsci.imagestats]
+repository = https://github.com/spacetelescope/stsci.imagestats
+script_setup =
+    pip install -e '.[test]'
+script =
+    pytest \
+    -r fEsx \
+    --basetemp="{{ func:basetemp_dir() }}" \
+    --junitxml="{{ func:junitxml_file() }}"
 
 [deploy:artifactory:delivery]
 files =

--- a/tests/data/gbo.yml
+++ b/tests/data/gbo.yml
@@ -8,3 +8,4 @@ dependencies:
     - firewatch==0.0.3
     - gwcs==0.22.1
     - tweakwcs==0.8.7
+    - stsci.imagestats==1.8.4

--- a/tests/data/gbo_ng.ini
+++ b/tests/data/gbo_ng.ini
@@ -19,7 +19,7 @@ pip_packages =
     firewatch==0.0.4
     gwcs==0.22.1
     tweakwcs==0.9.0
-
+    stsci.imagestats==1.8.4
 
 [runtime]
 CPPFLAGS = ${CPPFLAGS} -fpermissive
@@ -44,6 +44,15 @@ script =
         --basetemp="{{ func:basetemp_dir() }}" \
         --junitxml="{{ func:junitxml_file() }}"
 
+[test:stsci.imagestats]
+repository = https://github.com/spacetelescope/stsci.imagestats
+script_setup =
+    pip install -e '.[test]'
+script =
+    pytest \
+    -r fEsx \
+    --basetemp="{{ func:basetemp_dir() }}" \
+    --junitxml="{{ func:junitxml_file() }}"
 
 [deploy:artifactory:delivery]
 files =


### PR DESCRIPTION
- Introduces a workaround for `python -m build` generating wheels where `.` in the package name is now replaced with `_`
- Squelches a warning produced by `pip` during installation that claims `{index_url}/package-here` does not exist. Now we create a symbolic link using a `-` to separate package name elements.